### PR TITLE
Persist Theme Selection Using Redux and redux-persist

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,7 +10,7 @@ import AboutPage from "./components/AboutPage";
 import SystemSettings from "./components/SystemSettings";
 import Tab_Widgets from "./components/Tab_Widgets";
 import LightsheetController from "./components/LightsheetController";
-import DemoController from "./components/DemoController.js"
+import DemoController from "./components/DemoController.js";
 import BlocklyController from "./components/BlocklyController";
 import ImJoyView from "./components/ImJoyView";
 import JupyterExecutor from "./components/JupyterExecutor";
@@ -20,13 +20,11 @@ import ExtendedLEDMatrixController from "./components/ExtendedLEDMatrixControlle
 import StageOffsetCalibration from "./components/StageOffsetCalibrationController";
 import DetectorTriggerController from "./components/DetectorTriggerController";
 import StresstestController from "./components/StresstestController";
-import STORMController from "./components/STORMController.js";
 import STORMControllerArkitekt from "./components/STORMControllerArkitekt.js";
 import STORMControllerLocal from "./components/STORMControllerLocal.js";
 import FocusLockController from "./components/FocusLockController.js";
 import WiFiController from "./components/WiFiController.js";
 
-import theme from "./theme";
 import {
   Menu as MenuIcon,
   Dashboard as DashboardIcon,
@@ -58,6 +56,7 @@ import WebSocketHandler from "./middleware/WebSocketHandler";
 //redux
 import { useDispatch, useSelector } from "react-redux";
 import * as connectionSettingsSlice from "./state/slices/ConnectionSettingsSlice.js";
+import { toggleTheme, getThemeState } from "./state/slices/ThemeSlice";
 
 // Filemanager
 import FileManager from "./FileManager/FileManager/FileManager";
@@ -77,7 +76,6 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
-  Container,
   Box,
   Typography,
   AppBar,
@@ -89,7 +87,7 @@ import {
   ListItemIcon,
   ListItemText,
   CssBaseline,
-  Avatar, 
+  Avatar,
   Switch,
   TextField,
   MenuItem,
@@ -198,6 +196,7 @@ function App() {
   const connectionSettingsState = useSelector(
     connectionSettingsSlice.getConnectionSettingsState
   );
+  const { isDarkMode } = useSelector(getThemeState);
 
   /*
   States
@@ -221,7 +220,6 @@ function App() {
 
   const [selectedPlugin, setSelectedPlugin] = useState("LiveView"); // Control which plugin to show
   const [isDialogOpen, setDialogOpen] = useState(false);
-  const [isDarkMode, setIsDarkMode] = useState(true); // State to toggle between light and dark themes
   const [sharedImage, setSharedImage] = useState(null);
   const [fileManagerInitialPath, setFileManagerInitialPath] = useState("/");
   const [layout, setLayout] = useState([
@@ -441,13 +439,17 @@ function App() {
     handleCloseDialog();
 
     //redux
-    dispatch(connectionSettingsSlice.setIp(`${hostProtocol}${hostIP.replace(/^https?:\/\//, "")}`));
+    dispatch(
+      connectionSettingsSlice.setIp(
+        `${hostProtocol}${hostIP.replace(/^https?:\/\//, "")}`
+      )
+    );
     dispatch(connectionSettingsSlice.setWebsocketPort(websocketPort));
     dispatch(connectionSettingsSlice.setApiPort(apiPort));
   };
 
-  const toggleTheme = () => {
-    setIsDarkMode((prevMode) => !prevMode);
+  const handleToggleTheme = () => {
+    dispatch(toggleTheme());
   };
 
   const handlePluginChange = (plugin) => {
@@ -455,7 +457,7 @@ function App() {
   };
 
   const toggleGroup = (groupName) => {
-    setGroupsOpen(prev => {
+    setGroupsOpen((prev) => {
       const next = {
         ...prev,
         [groupName]: !prev[groupName],
@@ -583,7 +585,7 @@ function App() {
               </Typography>
               <Switch
                 checked={isDarkMode}
-                onChange={toggleTheme}
+                onChange={handleToggleTheme}
                 color="default"
                 inputProps={{ "aria-label": "toggle theme" }}
               />
@@ -620,12 +622,13 @@ function App() {
               </ListItem>
 
               {/* Apps Group */}
-              <ListItem button onClick={() => toggleGroup('apps')}>
+              <ListItem button onClick={() => toggleGroup("apps")}>
                 <ListItemIcon>
                   <AppsIcon />
                 </ListItemIcon>
                 <ListItemText primary={sidebarVisible ? "Apps" : ""} />
-                {sidebarVisible && (groupsOpen.apps ? <ExpandLess /> : <ExpandMore />)}
+                {sidebarVisible &&
+                  (groupsOpen.apps ? <ExpandLess /> : <ExpandMore />)}
               </ListItem>
               <Collapse in={groupsOpen.apps} timeout="auto" unmountOnExit>
                 <List component="div" disablePadding>
@@ -662,10 +665,12 @@ function App() {
                     onClick={() => handlePluginChange("STORMLocal")}
                     sx={{ pl: 4 }}
                   >
-                    <ListItemIcon>  
+                    <ListItemIcon>
                       <SettingsOverscanSharpIcon />
                     </ListItemIcon>
-                    <ListItemText primary={sidebarVisible ? "STORM Local" : ""} />
+                    <ListItemText
+                      primary={sidebarVisible ? "STORM Local" : ""}
+                    />
                   </ListItem>
 
                   {/* STORM Arkitekt */}
@@ -675,10 +680,12 @@ function App() {
                     onClick={() => handlePluginChange("STORMArkitekt")}
                     sx={{ pl: 4 }}
                   >
-                    <ListItemIcon>  
+                    <ListItemIcon>
                       <SettingsOverscanSharpIcon />
                     </ListItemIcon>
-                    <ListItemText primary={sidebarVisible ? "STORM Arkitekt" : ""} />
+                    <ListItemText
+                      primary={sidebarVisible ? "STORM Arkitekt" : ""}
+                    />
                   </ListItem>
 
                   {/* Infinity Scanning */}
@@ -706,7 +713,9 @@ function App() {
                     <ListItemIcon>
                       <ThreeDRotationIcon />
                     </ListItemIcon>
-                    <ListItemText primary={sidebarVisible ? "LightSheet" : ""} />
+                    <ListItemText
+                      primary={sidebarVisible ? "LightSheet" : ""}
+                    />
                   </ListItem>
 
                   {/* Demo */}
@@ -776,12 +785,13 @@ function App() {
               </ListItem>
 
               {/* Coding Group */}
-              <ListItem button onClick={() => toggleGroup('coding')}>
+              <ListItem button onClick={() => toggleGroup("coding")}>
                 <ListItemIcon>
                   <CodeIcon />
                 </ListItemIcon>
                 <ListItemText primary={sidebarVisible ? "Coding" : ""} />
-                {sidebarVisible && (groupsOpen.coding ? <ExpandLess /> : <ExpandMore />)}
+                {sidebarVisible &&
+                  (groupsOpen.coding ? <ExpandLess /> : <ExpandMore />)}
               </ListItem>
               <Collapse in={groupsOpen.coding} timeout="auto" unmountOnExit>
                 <List component="div" disablePadding>
@@ -829,12 +839,13 @@ function App() {
               </Collapse>
 
               {/* System Group */}
-              <ListItem button onClick={() => toggleGroup('system')}>
+              <ListItem button onClick={() => toggleGroup("system")}>
                 <ListItemIcon>
                   <ComputerIcon />
                 </ListItemIcon>
                 <ListItemText primary={sidebarVisible ? "System" : ""} />
-                {sidebarVisible && (groupsOpen.system ? <ExpandLess /> : <ExpandMore />)}
+                {sidebarVisible &&
+                  (groupsOpen.system ? <ExpandLess /> : <ExpandMore />)}
               </ListItem>
               <Collapse in={groupsOpen.system} timeout="auto" unmountOnExit>
                 <List component="div" disablePadding>
@@ -848,7 +859,9 @@ function App() {
                     <ListItemIcon>
                       <SettingsOverscanSharpIcon />
                     </ListItemIcon>
-                    <ListItemText primary={sidebarVisible ? "Stresstest" : ""} />
+                    <ListItemText
+                      primary={sidebarVisible ? "Stresstest" : ""}
+                    />
                   </ListItem>
 
                   {/* Objective */}
@@ -874,7 +887,9 @@ function App() {
                     <ListItemIcon>
                       <Icons.CenterFocusStrong />
                     </ListItemIcon>
-                    <ListItemText primary={sidebarVisible ? "Focus Lock" : ""} />
+                    <ListItemText
+                      primary={sidebarVisible ? "Focus Lock" : ""}
+                    />
                   </ListItem>
 
                   {/* SocketView */}
@@ -887,7 +902,9 @@ function App() {
                     <ListItemIcon>
                       <CommentIcon />
                     </ListItemIcon>
-                    <ListItemText primary={sidebarVisible ? "SocketView" : ""} />
+                    <ListItemText
+                      primary={sidebarVisible ? "SocketView" : ""}
+                    />
                   </ListItem>
 
                   {/* WiFi */}
@@ -913,7 +930,9 @@ function App() {
                     <ListItemIcon>
                       <WifiSharpIcon />
                     </ListItemIcon>
-                    <ListItemText primary={sidebarVisible ? "Connection Settings" : ""} />
+                    <ListItemText
+                      primary={sidebarVisible ? "Connection Settings" : ""}
+                    />
                   </ListItem>
 
                   {/* StageOffsetCalibration */}
@@ -964,14 +983,21 @@ function App() {
               </Collapse>
 
               {/* System Settings Group */}
-              <ListItem button onClick={() => toggleGroup('systemSettings')}>
+              <ListItem button onClick={() => toggleGroup("systemSettings")}>
                 <ListItemIcon>
                   <SettingsIcon />
                 </ListItemIcon>
-                <ListItemText primary={sidebarVisible ? "System Settings" : ""} />
-                {sidebarVisible && (groupsOpen.systemSettings ? <ExpandLess /> : <ExpandMore />)}
+                <ListItemText
+                  primary={sidebarVisible ? "System Settings" : ""}
+                />
+                {sidebarVisible &&
+                  (groupsOpen.systemSettings ? <ExpandLess /> : <ExpandMore />)}
               </ListItem>
-              <Collapse in={groupsOpen.systemSettings} timeout="auto" unmountOnExit>
+              <Collapse
+                in={groupsOpen.systemSettings}
+                timeout="auto"
+                unmountOnExit
+              >
                 <List component="div" disablePadding>
                   {/* UC2 */}
                   <ListItem
@@ -1082,10 +1108,10 @@ function App() {
               <HistoScanController hostIP={hostIP} hostPort={apiPort} />
             )}
             {selectedPlugin === "STORMLocal" && (
-                <STORMControllerLocal hostIP={hostIP} hostPort={apiPort} />
+              <STORMControllerLocal hostIP={hostIP} hostPort={apiPort} />
             )}
             {selectedPlugin === "STORMArkitekt" && (
-                <STORMControllerArkitekt hostIP={hostIP} hostPort={apiPort} />
+              <STORMControllerArkitekt hostIP={hostIP} hostPort={apiPort} />
             )}
             {selectedPlugin === "Stresstest" && (
               <StresstestController hostIP={hostIP} hostPort={apiPort} />
@@ -1208,9 +1234,11 @@ function App() {
                 id="protocol"
                 label="Protocol"
                 value={hostProtocol}
-                onChange={e => {
+                onChange={(e) => {
                   setHostProtocol(e.target.value);
-                  setHostIP(`${e.target.value}${hostIP.replace(/^https?:\/\//, "")}`);
+                  setHostIP(
+                    `${e.target.value}${hostIP.replace(/^https?:\/\//, "")}`
+                  );
                 }}
                 fullWidth
               >

--- a/src/state/slices/ThemeSlice.js
+++ b/src/state/slices/ThemeSlice.js
@@ -1,0 +1,22 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialState = {
+  isDarkMode: true,
+};
+
+const themeSlice = createSlice({
+  name: "themeState",
+  initialState,
+  reducers: {
+    toggleTheme: (state) => {
+      state.isDarkMode = !state.isDarkMode;
+    },
+    setDarkMode: (state, action) => {
+      state.isDarkMode = action.payload;
+    },
+  },
+});
+
+export const { toggleTheme, setDarkMode } = themeSlice.actions;
+export const getThemeState = (state) => state.themeState;
+export default themeSlice.reducer;

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -5,8 +5,6 @@ import { combineReducers } from "redux";
 
 // storage types
 import storage from "redux-persist/lib/storage";
-import storageSession from "redux-persist/lib/storage/session";
-
 
 // Import slices
 import connectionSettingsReducer from "./slices/ConnectionSettingsSlice";
@@ -36,6 +34,7 @@ import stormReducer from "./slices/STORMSlice";
 import focusLockReducer from "./slices/FocusLockSlice";
 import wifiReducer from "./slices/WiFiSlice";
 import demoReducer from "./slices/DemoSlice";
+import themeReducer from "./slices/ThemeSlice";
 
 //#####################################################################################
 // Combine reducers
@@ -67,6 +66,7 @@ const rootReducer = combineReducers({
   focusLockState: focusLockReducer,
   wifiState: wifiReducer,
   demoState: demoReducer,
+  themeState: themeReducer,
 });
 
 //#####################################################################################
@@ -82,6 +82,7 @@ const persistConfig = {
     "wellSelectorState",
     "positionState",
     "workflowState",
+    "themeState",
   ],
   //blacklist: ['webSocketState'],  // Do not persist these
 };
@@ -116,14 +117,14 @@ const rootReducerWithSync = (state, action) => {
 const syncStateAcrossTabs = () => {
   window.addEventListener("storage", (event) => {
     if (event.key === "persist:root") {
-        console.log("State change from another tab detected!");
+      console.log("State change from another tab detected!");
       const updatedState = JSON.parse(event.newValue);
-        // Check if any slice is stringified and needs parsing
-        Object.keys(updatedState).forEach(sliceKey => {
-            if (typeof updatedState[sliceKey] === "string") {
-              updatedState[sliceKey] = JSON.parse(updatedState[sliceKey]);
-            }
-          });
+      // Check if any slice is stringified and needs parsing
+      Object.keys(updatedState).forEach((sliceKey) => {
+        if (typeof updatedState[sliceKey] === "string") {
+          updatedState[sliceKey] = JSON.parse(updatedState[sliceKey]);
+        }
+      });
       // Dispatch SYNC_STATE action with updated state
       store.dispatch(syncStateAction(updatedState));
     }


### PR DESCRIPTION
Summary
This pull request migrates the theme (dark/light mode) management from local React state to the global Redux store. The theme state ([isDarkMode](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)) is now handled via a dedicated Redux slice (ThemeSlice) and is persisted in the browser using redux-persist. This ensures that the user's theme preference is retained even after reloading the page or restarting the application.

Changes
Added a new ThemeSlice for managing the [isDarkMode](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) state
Included themeState in the persistConfig.whitelist in the Redux store configuration
Removed local theme state from [App.js](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and replaced it with Redux state and selector
Theme switching is now handled via a Redux action ([toggleTheme](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html))
The selected theme is now persistent across browser reloads
Motivation
Centralized and consistent state management for user preferences
Improved user experience by remembering the selected theme
Consistent persistence behavior, similar to other settings (e.g., connection settings)