### PR TITLE
Adjust URL paths for reorganization of backend HTTP routes

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -3,7 +3,7 @@ const { ModuleFederationPlugin } = require("webpack").container;
 module.exports = {
   webpack: {
     configure: (config) => {
-      config.output.publicPath = "/imswitch";
+      config.output.publicPath = "/imswitch/ui";
 
       // Fix ES module resolution issues with luma.gl
       config.module.rules.push({

--- a/craco.config.js
+++ b/craco.config.js
@@ -3,7 +3,7 @@ const { ModuleFederationPlugin } = require("webpack").container;
 module.exports = {
   webpack: {
     configure: (config) => {
-      config.output.publicPath = "/imswitch/ui";
+      config.output.publicPath = "/imswitch/ui/";
 
       // Fix ES module resolution issues with luma.gl
       config.module.rules.push({

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "microscope-app",
   "version": "1.4.0",
   "private": true,
-  "homepage": "/imswitch",
+  "homepage": "/imswitch/ui",
   "dependencies": {
     "@blockly/theme-dark": "^8.0.1",
     "@deck.gl/core": "^9.2.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -134,7 +134,7 @@ function App() {
   */
   // Update fileUploadConfig to use hostIP (with protocol)
   const fileUploadConfig = {
-    url: `${hostIP}:${apiPort}/upload`,
+    url: `${hostIP}:${apiPort}/imswitch/api/FileManager/upload`,
   };
 
   // Fetch Files
@@ -210,7 +210,7 @@ function App() {
   };
 
   const handleOpenWithImJoy = (file) => {
-    const fileUrl = `${hostIP}:${apiPort}/FileManager/download/${file.path}`;
+    const fileUrl = `${hostIP}:${apiPort}/imswitch/api/FileManager/download/${file.path}`;
     setSharedImage({
       url: fileUrl,
       name: file.name,
@@ -248,7 +248,7 @@ function App() {
 
   // change API url/port and update filelist
   useEffect(() => {
-    api.defaults.baseURL = `${hostIP}:${apiPort}/FileManager`;
+    api.defaults.baseURL = `${hostIP}:${apiPort}/imswitch/api/FileManager`;
     handleRefresh();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hostIP, apiPort]);
@@ -273,7 +273,7 @@ function App() {
   PLUGIN LOADING from ImSwitch
   */
   function loadRemote({ remote, scope, exposed }) {
-    const url = `${hostIP}:${apiPort}${remote}`;
+    const url = `${hostIP}:${apiPort}/imswitch/api${remote}`;
 
     return new Promise((resolve, reject) => {
       if (!document.querySelector(`script[data-mf="${scope}"]`)) {
@@ -320,7 +320,7 @@ function App() {
       const fetchPlugins = async () => {
         try {
           // Construct the API URL dynamically using hostIP and apiPort
-          const apiUrl = `${hostIP}:${apiPort}/plugins`;
+          const apiUrl = `${hostIP}:${apiPort}/imswitch/api/plugins`;
 
           // Fetch the plugin data
           const response = await fetch(apiUrl);
@@ -451,7 +451,7 @@ function App() {
               >
                 <FileManager
                   key={`fm-${storageRefreshKey}`} // Force remount on storage change
-                  baseUrl={`${hostIP}:${apiPort}`}
+                  baseUrl={`${hostIP}:${apiPort}/imswitch`}
                   files={files}
                   fileUploadConfig={fileUploadConfig}
                   isLoading={isLoading}
@@ -468,7 +468,7 @@ function App() {
                   layout="list"
                   enableFilePreview
                   maxFileSize={10485760}
-                  filePreviewPath={`${hostIP}:${apiPort}/`}
+                  filePreviewPath={`${hostIP}:${apiPort}/imswitch`}
                   acceptedFileTypes=".txt, .png, .jpg, .jpeg, .pdf, .doc, .docx, .exe, .js, .csv"
                   initialPath={fileManagerInitialPath}
                 />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -453,7 +453,7 @@ function App() {
               >
                 <FileManager
                   key={`fm-${storageRefreshKey}`} // Force remount on storage change
-                  baseUrl={`${hostIP}:${apiPort}/imswitch`}
+                  baseUrl={`${hostIP}:${apiPort}/imswitch/api`}
                   files={files}
                   fileUploadConfig={fileUploadConfig}
                   isLoading={isLoading}
@@ -470,7 +470,7 @@ function App() {
                   layout="list"
                   enableFilePreview
                   maxFileSize={10485760}
-                  filePreviewPath={`${hostIP}:${apiPort}/imswitch`}
+                  filePreviewPath={`${hostIP}:${apiPort}/imswitch/api`}
                   acceptedFileTypes=".txt, .png, .jpg, .jpeg, .pdf, .doc, .docx, .exe, .js, .csv"
                   initialPath={fileManagerInitialPath}
                 />

--- a/src/FileManager/api/api.js
+++ b/src/FileManager/api/api.js
@@ -5,5 +5,5 @@ const hostPort = window.location.port || 4000;
 const protocol = window.location.protocol;
 
 export const api = axios.create({
-  baseURL: `${protocol}//${hostIP}:${hostPort}/FileManager`,
+  baseURL: `${protocol}//${hostIP}:${hostPort}/imswitch/api/FileManager`,
 });

--- a/src/MJPEGComponent..js
+++ b/src/MJPEGComponent..js
@@ -4,7 +4,7 @@ class MJPEGStream extends React.Component {
     render() {
         return (
             <img
-                src="http://192.168.2.223/imswitch/api/RecordingController/video_feeder"
+                src="{`${hostIP}:${apiPort}/imswitch/api/RecordingController/video_feeder`}"
                 alt="MJPEG Stream"
                 style={{ width: '100%' }}
             />

--- a/src/MJPEGComponent..js
+++ b/src/MJPEGComponent..js
@@ -4,7 +4,7 @@ class MJPEGStream extends React.Component {
     render() {
         return (
             <img
-                src="http://192.168.2.223:8001/RecordingController/video_feeder"
+                src="http://192.168.2.223/imswitch/api/RecordingController/video_feeder"
                 alt="MJPEG Stream"
                 style={{ width: '100%' }}
             />

--- a/src/__tests__/FocusLockController.test.js
+++ b/src/__tests__/FocusLockController.test.js
@@ -30,7 +30,7 @@ describe('FocusLockController', () => {
     
     render(
       <Provider store={store}>
-        <FocusLockController hostIP="http://localhost" hostPort="8001" />
+        <FocusLockController hostIP="http://localhost" hostPort="80" />
       </Provider>
     );
     
@@ -45,7 +45,7 @@ describe('FocusLockController', () => {
     
     render(
       <Provider store={store}>
-        <FocusLockController hostIP="http://localhost" hostPort="8001" />
+        <FocusLockController hostIP="http://localhost" hostPort="80" />
       </Provider>
     );
     

--- a/src/axon/ExperimentComponent.js
+++ b/src/axon/ExperimentComponent.js
@@ -162,7 +162,7 @@ const ExperimentComponent = () => {
     //    setfullURL(${omeZarrState.zarrUrl}`); // Switch to https if needed
 
     fetch(
-      `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/ExperimentController/getLastScanAsOMEZARR`
+      `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/imswitch/api/ExperimentController/getLastScanAsOMEZARR`
     )
       .then((res) => res.json())
       .then((data) => {
@@ -170,8 +170,8 @@ const ExperimentComponent = () => {
         const lastZarrPath = data || "";
         // English comment: build the final URL for VTK viewer
         // https://hms-dbmi.github.io/vizarr/?source=https://localhost:8001/data/ExperimentController/20250703_122249/20250703_122249_experiment0_0_experiment_0_.ome.zarr
-        // const viewerURL = `https://kitware.github.io/itk-vtk-viewer/app/?rotate=false&fileToLoad=${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/data${lastZarrPath}`;
-        const viewerURL = `https://hms-dbmi.github.io/vizarr/?source=${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/data${lastZarrPath}`;
+        // const viewerURL = `https://kitware.github.io/itk-vtk-viewer/app/?rotate=false&fileToLoad=${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/imswitch/api/data${lastZarrPath}`;
+        const viewerURL = `https://hms-dbmi.github.io/vizarr/?source=${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/imswitch/data${lastZarrPath}`;
         window.open(viewerURL, "_blank");
       })
       .catch((err) => {
@@ -187,7 +187,7 @@ const ExperimentComponent = () => {
     console.log("Fetching last OME-Zarr path to open in integrated Vizarr viewer");
     
     fetch(
-      `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/ExperimentController/getLastScanAsOMEZARR`
+      `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/imswitch/api/ExperimentController/getLastScanAsOMEZARR`
     )
       .then((res) => res.json())
       .then((data) => {

--- a/src/axon/ExperimentComponent.js
+++ b/src/axon/ExperimentComponent.js
@@ -169,7 +169,7 @@ const ExperimentComponent = () => {
         // English comment: 'data' should contain the relative path like "/recordings/...ome.zarr"
         const lastZarrPath = data || "";
         // English comment: build the final URL for VTK viewer
-        // https://hms-dbmi.github.io/vizarr/?source=https://localhost:8001/data/ExperimentController/20250703_122249/20250703_122249_experiment0_0_experiment_0_.ome.zarr
+        // https://hms-dbmi.github.io/vizarr/?source=https://localhost/imswitch/data/ExperimentController/20250703_122249/20250703_122249_experiment0_0_experiment_0_.ome.zarr
         // const viewerURL = `https://kitware.github.io/itk-vtk-viewer/app/?rotate=false&fileToLoad=${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/imswitch/api/data${lastZarrPath}`;
         const viewerURL = `https://hms-dbmi.github.io/vizarr/?source=${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/imswitch/data${lastZarrPath}`;
         window.open(viewerURL, "_blank");

--- a/src/axon/ParameterEditorComponent.js
+++ b/src/axon/ParameterEditorComponent.js
@@ -89,7 +89,7 @@ const ParameterEditorComponent = () => {
       try {
         const encodedLaserName = encodeURIComponent(laserName);
         await fetch(
-          `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/LaserController/setLaserValue?laserName=${encodedLaserName}&value=${value}`
+          `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/imswitch/api/LaserController/setLaserValue?laserName=${encodedLaserName}&value=${value}`
         );
       } catch (error) {
         console.error("Failed to update laser intensity in backend:", error);

--- a/src/axon/WebRTCViewer.jsx
+++ b/src/axon/WebRTCViewer.jsx
@@ -32,7 +32,7 @@ const WebRTCViewer = ({ detectorName, onDoubleClick }) => {
   const connectionSettings = useSelector(
     (state) => state.connectionSettingsState
   );
-  const baseUrl = `${connectionSettings.ip}:${connectionSettings.apiPort}`;
+  const baseUrl = `${connectionSettings.ip}:${connectionSettings.apiPort}/imswitch/api`;
 
   // Detect if connection is local
   const isLocalConnection = useCallback(() => {

--- a/src/axon/ZarrTileView.js
+++ b/src/axon/ZarrTileView.js
@@ -29,8 +29,8 @@ const ZarrTileViewController = () => {
   // log debug info
   useEffect(() => {
     console.info("[ZARR-VIEW] new zarrUrl ➜", omeZarrState.zarrUrl);
-    // e.g. https://avivator.gehlenborglab.org/?image_url=https://localhost:8001/data/ExperimentController/20250603_140818_FastStageScan.ome.zarr
-    setfullURL(`${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/data${omeZarrState.zarrUrl}`); // Switch to https if needed
+    // e.g. https://avivator.gehlenborglab.org/?image_url=https://localhost/imswitch/data/ExperimentController/20250603_140818_FastStageScan.ome.zarr
+    setfullURL(`${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/imswitch/data${omeZarrState.zarrUrl}`); // Switch to https if needed
   }, [omeZarrState.zarrUrl]);
 
   useEffect(() => {

--- a/src/axon/experiment-designer/ChannelsDimension.js
+++ b/src/axon/experiment-designer/ChannelsDimension.js
@@ -295,7 +295,7 @@ const ChannelsDimension = () => {
             const otherLaserName = illuSources[i];
             const encodedOtherLaserName = encodeURIComponent(otherLaserName);
             await fetch(
-              `${connectionSettings.ip}:${connectionSettings.apiPort}/LaserController/setLaserValue?laserName=${encodedOtherLaserName}&value=0`
+              `${connectionSettings.ip}:${connectionSettings.apiPort}/imswitch/api/LaserController/setLaserValue?laserName=${encodedOtherLaserName}&value=0`
             );
           }
         }
@@ -303,7 +303,7 @@ const ChannelsDimension = () => {
         // Then set the selected channel with its intensity
         const encodedLaserName = encodeURIComponent(laserName);
         await fetch(
-          `${connectionSettings.ip}:${connectionSettings.apiPort}/LaserController/setLaserValue?laserName=${encodedLaserName}&value=${value}`
+          `${connectionSettings.ip}:${connectionSettings.apiPort}/imswitch/api/LaserController/setLaserValue?laserName=${encodedLaserName}&value=${value}`
         );
 
         // Also send exposure time and gain for this channel
@@ -311,11 +311,11 @@ const ChannelsDimension = () => {
         const currentGain = gains[index] ?? 0;
         
         await fetch(
-          `${connectionSettings.ip}:${connectionSettings.apiPort}/SettingsController/setDetectorExposureTime?exposureTime=${currentExposure}`
+          `${connectionSettings.ip}:${connectionSettings.apiPort}/imswitch/api/SettingsController/setDetectorExposureTime?exposureTime=${currentExposure}`
         );
         
         await fetch(
-          `${connectionSettings.ip}:${connectionSettings.apiPort}/SettingsController/setDetectorGain?gain=${currentGain}`
+          `${connectionSettings.ip}:${connectionSettings.apiPort}/imswitch/api/SettingsController/setDetectorGain?gain=${currentGain}`
         );
       } catch (error) {
         console.error("Failed to update laser intensity:", error);
@@ -332,7 +332,7 @@ const ChannelsDimension = () => {
     // update backend immediately for real-time feedback
     if ( connectionSettings.ip && connectionSettings.apiPort) {
       fetch(
-        `${connectionSettings.ip}:${connectionSettings.apiPort}/SettingsController/setDetectorExposureTime?exposureTime=${value}`
+        `${connectionSettings.ip}:${connectionSettings.apiPort}/imswitch/api/SettingsController/setDetectorExposureTime?exposureTime=${value}`
       ).catch((error) => {
         console.error("Failed to update detector exposure time:", error);
       });
@@ -347,7 +347,7 @@ const ChannelsDimension = () => {
     // update backend immediately for real-time feedback
     if (connectionSettings.ip && connectionSettings.apiPort) {
       fetch(
-        `${connectionSettings.ip}:${connectionSettings.apiPort}/SettingsController/setDetectorGain?gain=${value}`
+        `${connectionSettings.ip}:${connectionSettings.apiPort}/imswitch/api/SettingsController/setDetectorGain?gain=${value}`
       ).catch((error) => {
         console.error("Failed to update detector gain:", error);
       });

--- a/src/axon/experiment-designer/ExperimentDesigner.js
+++ b/src/axon/experiment-designer/ExperimentDesigner.js
@@ -208,7 +208,7 @@ const ExperimentDesigner = () => {
 
   const handleOpenVizarr = () => {
     fetch(
-      `${connectionSettings.ip}:${connectionSettings.apiPort}/ExperimentController/getLastScanAsOMEZARR`
+      `${connectionSettings.ip}:${connectionSettings.apiPort}/imswitch/api/ExperimentController/getLastScanAsOMEZARR`
     )
       .then((res) => res.json())
       .then((data) => {

--- a/src/backendapi/apiLightsheetCameraSettings.js
+++ b/src/backendapi/apiLightsheetCameraSettings.js
@@ -8,7 +8,7 @@ export async function apiGetCameraExposureTime() {
   const state = store.getState();
   const { ip, apiPort } = state.connectionSettingsState;
   
-  const url = `${ip}:${apiPort}/LightsheetController/getCameraExposureTime`;
+  const url = `${ip}:${apiPort}/imswitch/api/LightsheetController/getCameraExposureTime`;
   
   try {
     const response = await fetch(url);
@@ -31,7 +31,7 @@ export async function apiSetCameraExposureTime(exposureTime) {
   const state = store.getState();
   const { ip, apiPort } = state.connectionSettingsState;
   
-  const url = `${ip}:${apiPort}/LightsheetController/setCameraExposureTime?exposureTime=${exposureTime}`;
+  const url = `${ip}:${apiPort}/imswitch/api/LightsheetController/setCameraExposureTime?exposureTime=${exposureTime}`;
   
   try {
     const response = await fetch(url, { method: "GET" });
@@ -53,7 +53,7 @@ export async function apiGetCameraGain() {
   const state = store.getState();
   const { ip, apiPort } = state.connectionSettingsState;
   
-  const url = `${ip}:${apiPort}/LightsheetController/getCameraGain`;
+  const url = `${ip}:${apiPort}/imswitch/api/LightsheetController/getCameraGain`;
   
   try {
     const response = await fetch(url);
@@ -76,7 +76,7 @@ export async function apiSetCameraGain(gain) {
   const state = store.getState();
   const { ip, apiPort } = state.connectionSettingsState;
   
-  const url = `${ip}:${apiPort}/LightsheetController/setCameraGain?gain=${gain}`;
+  const url = `${ip}:${apiPort}/imswitch/api/LightsheetController/setCameraGain?gain=${gain}`;
   
   try {
     const response = await fetch(url, { method: "GET" });

--- a/src/backendapi/apiUC2ConfigControllerStartMultipleDeviceOTA.js
+++ b/src/backendapi/apiUC2ConfigControllerStartMultipleDeviceOTA.js
@@ -18,7 +18,7 @@ const apiUC2ConfigControllerStartMultipleDeviceOTA = async (canIds, ssid = null,
     
     /*
     curl -X 'POST' \
-      'http://localhost:8001/UC2ConfigController/startMultipleDeviceOTA?timeout=300000' \
+      'http://localhost/imswitch/api/UC2ConfigController/startMultipleDeviceOTA?timeout=300000' \
       -H 'accept: application/json' \
       -H 'Content-Type: application/json' \
       -d '[10, 20]'

--- a/src/backendapi/createAxiosInstance.js
+++ b/src/backendapi/createAxiosInstance.js
@@ -5,7 +5,7 @@ import store from '../state/store';
 const createAxiosInstance = () => {
   //get settings
   const state = store.getState(); 
-  const rootPath = '/imswitch/api`;
+  const rootPath = '/imswitch/api';
   //create instance
   return axios.create({
     baseURL: `${state.connectionSettingsState.ip}:${state.connectionSettingsState.apiPort}${rootPath}`,

--- a/src/backendapi/createAxiosInstance.js
+++ b/src/backendapi/createAxiosInstance.js
@@ -5,9 +5,10 @@ import store from '../state/store';
 const createAxiosInstance = () => {
   //get settings
   const state = store.getState(); 
+  const rootPath = '/imswitch/api`;
   //create instance
   return axios.create({
-    baseURL: `${state.connectionSettingsState.ip}:${state.connectionSettingsState.apiPort}`,
+    baseURL: `${state.connectionSettingsState.ip}:${state.connectionSettingsState.apiPort}${rootPath}`,
   });
 };
 

--- a/src/backendapi/dpcApi.js
+++ b/src/backendapi/dpcApi.js
@@ -5,7 +5,7 @@ import axios from "axios";
 
 /**
  * Get current DPC parameters
- * @param {string} baseUrl - Base URL of the backend API (e.g., "http://localhost:8001")
+ * @param {string} baseUrl - Base URL of the backend API (e.g., "http://localhost/imswitch/api")
  * @returns {Promise<Object>} DPC parameters
  */
 export const getDpcParams = async (baseUrl) => {

--- a/src/components/AboutPage.js
+++ b/src/components/AboutPage.js
@@ -44,7 +44,7 @@ const AboutPage = () => {
 
   const hostIP = connectionSettings.ip || "http://localhost";
   const hostPort = connectionSettings.apiPort || "8000";
-  const apiDocsUrl = `${hostIP}:${hostPort}/docs`;
+  const apiDocsUrl = `${hostIP}:${hostPort}/imswitch/api/docs`;
 
   // Backend version state
   const [backendVersion, setBackendVersion] = useState(null);
@@ -63,7 +63,7 @@ const AboutPage = () => {
 
         // Use cross-browser compatible fetch with timeout
         const response = await fetchWithTimeout(
-          `${hostIP}:${hostPort}/version`,
+          `${hostIP}:${hostPort}/imswitch/api/version`,
           { method: "GET" },
           5000
         );

--- a/src/components/AcceptanceTestComponent.jsx
+++ b/src/components/AcceptanceTestComponent.jsx
@@ -47,10 +47,12 @@ import {
   Assessment as ReportIcon,
   Download as DownloadIcon
 } from '@mui/icons-material';
+import { useDispatch, useSelector } from "react-redux";
 
 // Import LiveView component
 import LiveViewControlWrapper from '../axon/LiveViewControlWrapper';
 
+import * as connectionSettingsSlice from "../state/slices/ConnectionSettingsSlice.js";
 // Import API functions
 import apiAcceptanceTestControllerHomeAxisX from '../backendapi/apiAcceptanceTestControllerHomeAxisX';
 import apiAcceptanceTestControllerHomeAxisY from '../backendapi/apiAcceptanceTestControllerHomeAxisY';
@@ -79,6 +81,8 @@ const AcceptanceTestComponent = () => {
   // Centralized decision storage - THIS IS THE KEY FIX
   // Structure: { testId: 'yes' | 'no' | 'skip' }
   const [decisions, setDecisions] = useState({});
+  
+  const connectionSettings = useSelector(connectionSettingsSlice.getConnectionSettingsState);
   
   // Track which actions have been started (for enabling Yes/No buttons)
   // Structure: { testId: boolean }
@@ -939,7 +943,7 @@ const AcceptanceTestComponent = () => {
                         const value = e.target.value;
                         setExposure(value);
                         try {
-                          await fetch(`http://localhost/imswitch/api/SettingsController/setDetectorExposureTime?exposureTime=${value}`);
+                          await fetch(`${connectionSettings.ip}:${connectionSettings.apiPort}/imswitch/api/SettingsController/setDetectorExposureTime?exposureTime=${value}`);
                         } catch (err) {
                           console.error('Error setting exposure:', err);
                         }
@@ -956,7 +960,7 @@ const AcceptanceTestComponent = () => {
                         const value = e.target.value;
                         setGain(value);
                         try {
-                          await fetch(`http://localhost/imswitch/api/SettingsController/setDetectorGain?gain=${value}`);
+                          await fetch(`${connectionSettings.ip}:${connectionSettings.apiPort}/imswitch/api/SettingsController/setDetectorGain?gain=${value}`);
                         } catch (err) {
                           console.error('Error setting gain:', err);
                         }

--- a/src/components/AcceptanceTestComponent.jsx
+++ b/src/components/AcceptanceTestComponent.jsx
@@ -939,7 +939,7 @@ const AcceptanceTestComponent = () => {
                         const value = e.target.value;
                         setExposure(value);
                         try {
-                          await fetch(`http://localhost:8001/SettingsController/setDetectorExposureTime?exposureTime=${value}`);
+                          await fetch(`http://localhost/imswitch/api/SettingsController/setDetectorExposureTime?exposureTime=${value}`);
                         } catch (err) {
                           console.error('Error setting exposure:', err);
                         }
@@ -956,7 +956,7 @@ const AcceptanceTestComponent = () => {
                         const value = e.target.value;
                         setGain(value);
                         try {
-                          await fetch(`http://localhost:8001/SettingsController/setDetectorGain?gain=${value}`);
+                          await fetch(`http://localhost/imswitch/api/SettingsController/setDetectorGain?gain=${value}`);
                         } catch (err) {
                           console.error('Error setting gain:', err);
                         }

--- a/src/components/AutofocusController.js
+++ b/src/components/AutofocusController.js
@@ -73,7 +73,7 @@ const AutofocusController = ({ hostIP, hostPort }) => {
     try {
       for (const illumination of availableIlluminations) {
         const encodedName = encodeURIComponent(illumination);
-        const response = await fetch(`${ip}:${port}/LaserController/getLaserValue?laserName=${encodedName}`);
+        const response = await fetch(`${ip}:${port}/imswitch/api/LaserController/getLaserValue?laserName=${encodedName}`);
         if (response.ok) {
           const value = await response.json();
           if (value > 0) {
@@ -105,7 +105,7 @@ const AutofocusController = ({ hostIP, hostPort }) => {
   const handleStart = () => {
     // Use selected illumination channel or fallback to currently active one
     const selectedChannel = illuminationChannel || availableIlluminations[0];
-    const url = `${hostIP}:${hostPort}/AutofocusController/autoFocus?rangez=${rangeZ}&resolutionz=${resolutionZ}&defocusz=${defocusZ}&illuminationChannel=${encodeURIComponent(selectedChannel || '')}&tSettle=${tSettle}&isDebug=${isDebug}&nGauss=${nGauss}&nCropsize=${nCropsize}&focusAlgorithm=${focusAlgorithm}&static_offset=${staticOffset}&twoStage=${twoStage}`;
+    const url = `${hostIP}:${hostPort}/imswitch/api/AutofocusController/autoFocus?rangez=${rangeZ}&resolutionz=${resolutionZ}&defocusz=${defocusZ}&illuminationChannel=${encodeURIComponent(selectedChannel || '')}&tSettle=${tSettle}&isDebug=${isDebug}&nGauss=${nGauss}&nCropsize=${nCropsize}&focusAlgorithm=${focusAlgorithm}&static_offset=${staticOffset}&twoStage=${twoStage}`;
     fetch(url, { method: "GET" })
       .then((response) => response.json())
       .then(() => {
@@ -117,7 +117,7 @@ const AutofocusController = ({ hostIP, hostPort }) => {
   };
 
   const handleStop = () => {
-    const url = `${hostIP}:${hostPort}/AutofocusController/stopAutoFocus`;
+    const url = `${hostIP}:${hostPort}/imswitch/api/AutofocusController/stopAutoFocus`;
     fetch(url, { method: "GET" })
       .then((response) => response.json())
       .then(() => dispatch(autofocusSlice.setIsRunning(false)))

--- a/src/components/AxisControl.jsx
+++ b/src/components/AxisControl.jsx
@@ -61,7 +61,7 @@ const ImprovedAxisControl = ({ hostIP, hostPort }) => {
     (async () => {
       try {
         const r = await fetch(
-          `${hostIP}:${hostPort}/PositionerController/getPositionerNames`
+          `${hostIP}:${hostPort}/imswitch/api/PositionerController/getPositionerNames`
         );
         const d = await r.json();
         setPositionerName(d[0]);
@@ -93,7 +93,7 @@ const ImprovedAxisControl = ({ hostIP, hostPort }) => {
     }
   };
 
-  const base = `${hostIP}:${hostPort}/PositionerController`;
+  const base = `${hostIP}:${hostPort}/imswitch/api/PositionerController`;
 
   const moveAxis = (axis, distance) =>
     call(

--- a/src/components/ConfigurationEditorController.js
+++ b/src/components/ConfigurationEditorController.js
@@ -68,7 +68,7 @@ const ConfigurationEditorController = ({ hostIP, hostPort }) => {
   const [showConfigWizard, setShowConfigWizard] = React.useState(false);
 
   const fetchCurrentActiveFilename = useCallback(() => {
-    const url = `${hostIP}:${hostPort}/UC2ConfigController/getCurrentSetupFilename`;
+    const url = `${hostIP}:${hostPort}/imswitch/api/UC2ConfigController/getCurrentSetupFilename`;
     dispatch(uc2Slice.setIsLoadingCurrentFilename(true));
     
     fetch(url)
@@ -111,7 +111,7 @@ const ConfigurationEditorController = ({ hostIP, hostPort }) => {
   }, [hostIP, hostPort, dispatch]);
 
   const fetchAvailableSetups = useCallback(() => {
-    const url = `${hostIP}:${hostPort}/UC2ConfigController/returnAvailableSetups`;
+    const url = `${hostIP}:${hostPort}/imswitch/api/UC2ConfigController/returnAvailableSetups`;
     dispatch(
       setNotification({
         message: "Loading available setups...",
@@ -169,7 +169,7 @@ const ConfigurationEditorController = ({ hostIP, hostPort }) => {
       })
     );
 
-    const url = `${hostIP}:${hostPort}/UC2ConfigController/readSetupFile?setupFileName=${encodeURIComponent(
+    const url = `${hostIP}:${hostPort}/imswitch/api/UC2ConfigController/readSetupFile?setupFileName=${encodeURIComponent(
       fileName
     )}`;
 
@@ -348,7 +348,7 @@ const ConfigurationEditorController = ({ hostIP, hostPort }) => {
       })
     );
 
-    const url = `${hostIP}:${hostPort}/UC2ConfigController/writeNewSetupFile?setupFileName=${encodeURIComponent(
+    const url = `${hostIP}:${hostPort}/imswitch/api/UC2ConfigController/writeNewSetupFile?setupFileName=${encodeURIComponent(
       newFileName
     )}&setAsCurrentConfig=${setAsCurrentConfig}&restart=${restartAfterSave}&overwrite=${overwriteFile}`;
 

--- a/src/components/ConfigurationWizard.js
+++ b/src/components/ConfigurationWizard.js
@@ -95,7 +95,7 @@ const ConfigurationWizard = ({ open, onClose, hostIP, hostPort }) => {
   }, [selectedSource]);
 
   const fetchCurrentActiveFilename = useCallback(() => {
-    const url = `${hostIP}:${hostPort}/UC2ConfigController/getCurrentSetupFilename`;
+    const url = `${hostIP}:${hostPort}/imswitch/api/UC2ConfigController/getCurrentSetupFilename`;
     fetch(url)
       .then((response) => {
         if (!response.ok) {
@@ -124,7 +124,7 @@ const ConfigurationWizard = ({ open, onClose, hostIP, hostPort }) => {
   }, [hostIP, hostPort]);
 
   const fetchAvailableSetups = useCallback(() => {
-    const url = `${hostIP}:${hostPort}/UC2ConfigController/returnAvailableSetups`;
+    const url = `${hostIP}:${hostPort}/imswitch/api/UC2ConfigController/returnAvailableSetups`;
     fetch(url)
       .then((response) => response.json())
       .then((data) => {
@@ -184,7 +184,7 @@ const ConfigurationWizard = ({ open, onClose, hostIP, hostPort }) => {
     setLoadError('');
     
     // Use the readSetupFile API without setupFileName parameter to get current config
-    const url = `${hostIP}:${hostPort}/UC2ConfigController/readSetupFile`;
+    const url = `${hostIP}:${hostPort}/imswitch/api/UC2ConfigController/readSetupFile`;
     
     fetch(url)
       .then((response) => {
@@ -210,7 +210,7 @@ const ConfigurationWizard = ({ open, onClose, hostIP, hostPort }) => {
     setIsLoading(true);
     setLoadError('');
     
-    const url = `${hostIP}:${hostPort}/UC2ConfigController/readSetupFile?setupFileName=${encodeURIComponent(fileName)}`;
+    const url = `${hostIP}:${hostPort}/imswitch/api/UC2ConfigController/readSetupFile?setupFileName=${encodeURIComponent(fileName)}`;
     
     fetch(url)
       .then((response) => {
@@ -334,7 +334,7 @@ const ConfigurationWizard = ({ open, onClose, hostIP, hostPort }) => {
       return;
     }
 
-    const url = `${hostIP}:${hostPort}/UC2ConfigController/writeNewSetupFile?setupFileName=${encodeURIComponent(
+    const url = `${hostIP}:${hostPort}/imswitch/api/UC2ConfigController/writeNewSetupFile?setupFileName=${encodeURIComponent(
       filename
     )}&setAsCurrentConfig=${setAsCurrentConfig}&restart=${restartAfterSave}&overwrite=${overwriteFile}`;
 
@@ -367,7 +367,7 @@ const ConfigurationWizard = ({ open, onClose, hostIP, hostPort }) => {
     const maxRetries = 30;
     
     const checkStatus = () => {
-      fetch(`${hostIP}:${hostPort}/UC2ConfigController/is_connected`)
+      fetch(`${hostIP}:${hostPort}/imswitch/api/UC2ConfigController/is_connected`)
         .then((res) => res.json())
         .then((data) => {
           if (data === true) {

--- a/src/components/ConnectionSettings.jsx
+++ b/src/components/ConnectionSettings.jsx
@@ -70,8 +70,8 @@ function ConnectionSettings() {
       protocol: isHttps ? "https://" : "http://",
       hostname: location.hostname,
       // Use current port if available. If empty on HTTPS, it implies 443.
-      // Default to 8001 only on non-standard HTTP setups.
-      port: location.port || (isHttps ? "443" : "8001"),
+      // Default to 80 only on non-standard HTTP setups.
+      port: location.port || (isHttps ? "443" : "80"),
     };
   };
 
@@ -437,7 +437,7 @@ function ConnectionSettings() {
             </AccordionSummary>
             <AccordionDetails>
               <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-                Both services typically run on port 8001. Only change these if
+                Both services typically run on port 80. Only change these if
                 you have a custom setup.
               </Typography>
 
@@ -457,7 +457,7 @@ function ConnectionSettings() {
                   value={websocketPort}
                   onChange={(e) => setWebsocketPortState(e.target.value.trim())}
                   fullWidth
-                  placeholder="e.g., 8001"
+                  placeholder="e.g., 80"
                 />
 
                 {/* API Port */}
@@ -468,7 +468,7 @@ function ConnectionSettings() {
                   value={apiPort}
                   onChange={(e) => setApiPortState(e.target.value.trim())}
                   fullWidth
-                  placeholder="e.g., 8001"
+                  placeholder="e.g., 80"
                 />
               </Box>
             </AccordionDetails>
@@ -638,7 +638,7 @@ function ConnectionSettings() {
               </ListItemIcon>
               <ListItemText
                 primary="Local Development"
-                secondary="IP: localhost, API Port: 8000, WebSocket Port: 8001"
+                secondary="IP: localhost, API Port: 8000, WebSocket Port: 80"
               />
             </ListItem>
             <ListItem>

--- a/src/components/ConnectionSettings.jsx
+++ b/src/components/ConnectionSettings.jsx
@@ -501,7 +501,7 @@ function ConnectionSettings() {
                         )
                           ? `:${apiPort}`
                           : ""
-                      }`}
+                      }/imswitch/api`}
                     />
                     <Chip
                       label={isBackendConnected ? "Connected" : "Disconnected"}
@@ -529,7 +529,7 @@ function ConnectionSettings() {
                           )
                             ? `:${websocketPort}`
                             : ""
-                        }`}
+                        }/imswitch/socket.io`}
                       />
                       <Chip
                         label={getWebSocketStatusLabel(websocketTestStatus)}

--- a/src/components/DPCController.js
+++ b/src/components/DPCController.js
@@ -62,7 +62,7 @@ const DPCController = () => {
   const processedImageRef = useRef(null);
 
   // Build stream URLs
-  const baseUrl = `${connectionSettings.ip}:${connectionSettings.apiPort}`;
+  const baseUrl = `${connectionSettings.ip}:${connectionSettings.apiPort}/imswitch/api`;
   const rawStreamUrl = `${baseUrl}/RecordingController/video_feeder`;
   const processedStreamUrl = getDpcStreamUrl(baseUrl, 85);
 

--- a/src/components/DetectorParameters.js
+++ b/src/components/DetectorParameters.js
@@ -41,7 +41,7 @@ export default function DetectorParameters({ hostIP, hostPort }) {
     async function fetchParams() {
       try {
         const resp = await fetch(
-          `${hostIP}:${hostPort}/SettingsController/getDetectorParameters`
+          `${hostIP}:${hostPort}/imswitch/api/SettingsController/getDetectorParameters`
         );
         if (resp.ok) {
           const data = await resp.json();
@@ -70,28 +70,28 @@ export default function DetectorParameters({ hostIP, hostPort }) {
       switch (field) {
         case "exposure":
           await fetch(
-            `${hostIP}:${hostPort}/SettingsController/setDetectorExposureTime?exposureTime=${value}`
+            `${hostIP}:${hostPort}/imswitch/api/SettingsController/setDetectorExposureTime?exposureTime=${value}`
           );
           break;
         case "gain":
           await fetch(
-            `${hostIP}:${hostPort}/SettingsController/setDetectorGain?gain=${value}`
+            `${hostIP}:${hostPort}/imswitch/api/SettingsController/setDetectorGain?gain=${value}`
           );
           break;
         case "binning":
           await fetch(
-            `${hostIP}:${hostPort}/SettingsController/setDetectorBinning?binning=${value}`
+            `${hostIP}:${hostPort}/imswitch/api/SettingsController/setDetectorBinning?binning=${value}`
           );
           break;
         case "blacklevel":
           await fetch(
-            `${hostIP}:${hostPort}/SettingsController/setDetectorBlackLevel?blacklevel=${value}`
+            `${hostIP}:${hostPort}/imswitch/api/SettingsController/setDetectorBlackLevel?blacklevel=${value}`
           );
           break;
         case "isRGB": {
           const intVal = value ? 1 : 0;
           await fetch(
-            `${hostIP}:${hostPort}/SettingsController/setDetectorIsRGB?isRGB=${intVal}`
+            `${hostIP}:${hostPort}/imswitch/api/SettingsController/setDetectorIsRGB?isRGB=${intVal}`
           );
           break;
         }
@@ -99,7 +99,7 @@ export default function DetectorParameters({ hostIP, hostPort }) {
           // If the API expects e.g. `isAuto=true` for "auto" mode:
           const isAuto = value === "auto";
           await fetch(
-            `${hostIP}:${hostPort}/SettingsController/setDetectorMode?isAuto=${isAuto}`
+            `${hostIP}:${hostPort}/imswitch/api/SettingsController/setDetectorMode?isAuto=${isAuto}`
           );
           break;
         }

--- a/src/components/DetectorTriggerController.js
+++ b/src/components/DetectorTriggerController.js
@@ -17,7 +17,7 @@ import { getConnectionSettingsState } from "../state/slices/ConnectionSettingsSl
 /* Axios factory bound to the camera host */
 const createAxiosInstance = (ip, port) =>
   axios.create({
-    baseURL: `${ip}:${port}`,
+    baseURL: `${ip}:${port}/imswitch/api`,
     timeout: 6000,
   });
 

--- a/src/components/FRAMESettings/PixelCalibrationTab.js
+++ b/src/components/FRAMESettings/PixelCalibrationTab.js
@@ -60,7 +60,7 @@ const PixelCalibrationTab = () => {
   // Set up overview stream URL
   useEffect(() => {
     if (hostIP && hostPort) {
-      setOverviewStreamUrl(`${hostIP}:${hostPort}/PixelCalibrationController/overviewStream`);
+      setOverviewStreamUrl(`${hostIP}:${hostPort}/imswitch/api/PixelCalibrationController/overviewStream`);
     }
   }, [hostIP, hostPort]);
 

--- a/src/components/FRAMESettings/SetLasersTab.js
+++ b/src/components/FRAMESettings/SetLasersTab.js
@@ -59,7 +59,7 @@ const SetLasersTab = () => {
   // Set up overview stream URL
   useEffect(() => {
     if (hostIP && hostPort) {
-      setOverviewStreamUrl(`${hostIP}:${hostPort}/PixelCalibrationController/overviewStream`);
+      setOverviewStreamUrl(`${hostIP}:${hostPort}/imswitch/api/PixelCalibrationController/overviewStream`);
     }
   }, [hostIP, hostPort]);
 

--- a/src/components/FRAMESettings/TestHomingTab.js
+++ b/src/components/FRAMESettings/TestHomingTab.js
@@ -71,7 +71,7 @@ const TestHomingTab = () => {
   // Set up stream URL
   useEffect(() => {
     if (hostIP && hostPort) {
-      setStreamUrl(`${hostIP}:${hostPort}/PixelCalibrationController/overviewStream`);
+      setStreamUrl(`${hostIP}:${hostPort}/imswitch/api/PixelCalibrationController/overviewStream`);
     }
   }, [hostIP, hostPort]);
 

--- a/src/components/FRAMESettings/TrackMotionTab.js
+++ b/src/components/FRAMESettings/TrackMotionTab.js
@@ -87,7 +87,7 @@ const TrackMotionTab = () => {
   // Set up stream URL
   useEffect(() => {
     if (hostIP && hostPort) {
-      setStreamUrl(`${hostIP}:${hostPort}/PixelCalibrationController/overviewStream`);
+      setStreamUrl(`${hostIP}:${hostPort}/imswitch/api/PixelCalibrationController/overviewStream`);
     }
   }, [hostIP, hostPort]);
 

--- a/src/components/FlowStopController.js
+++ b/src/components/FlowStopController.js
@@ -124,7 +124,7 @@ const FlowStopController = () => {
   }, [socket]);
 
   const startExperiment = () => {
-    // https://localhost:8001/FlowStopController/startFlowStopExperimentFastAPI?timeStamp=asdf&experimentName=adf&experimentDescription=asdf&uniqueId=asdf&numImages=19&volumePerImage=199&timeToStabilize=1&delayToStart=1&frameRate=1&filePath=.%2F&fileFormat=TIF&isRecordVideo=true&pumpSpeed=10000
+    // https://localhost/imswitch/api/FlowStopController/startFlowStopExperimentFastAPI?timeStamp=asdf&experimentName=adf&experimentDescription=asdf&uniqueId=asdf&numImages=19&volumePerImage=199&timeToStabilize=1&delayToStart=1&frameRate=1&filePath=.%2F&fileFormat=TIF&isRecordVideo=true&pumpSpeed=10000
     // Build URL from Redux connection settings
     const url = `${hostIP}:${hostPort}/imswitch/api/FlowStopController/startFlowStopExperimentFastAPI?timeStamp=${timeStamp}&experimentName=${experimentName}&experimentDescription=${experimentDescription}&uniqueId=${uniqueId}&numImages=${numImages}&volumePerImage=${volumePerImage}&timeToStabilize=${timeToStabilize}&isRecordVideo=true&pumpSpeed=${pumpSpeed}`;
     fetch(url, { method: "GET" })

--- a/src/components/FlowStopController.js
+++ b/src/components/FlowStopController.js
@@ -63,7 +63,7 @@ const FlowStopController = () => {
     const fetchStatus = async () => {
       try {
         const response = await fetch(
-          `${hostIP}:${hostPort}/FlowStopController/getStatus`
+          `${hostIP}:${hostPort}/imswitch/api/FlowStopController/getStatus`
         );
         const data = await response.json();
         dispatch(flowStopSlice.setIsRunning(data[0]));
@@ -76,7 +76,7 @@ const FlowStopController = () => {
     const fetchExperimentParameters = async () => {
       try {
         const response = await fetch(
-          `${hostIP}:${hostPort}/FlowStopController/getExperimentParameters`
+          `${hostIP}:${hostPort}/imswitch/api/FlowStopController/getExperimentParameters`
         );
         const data = await response.json();
         dispatch(flowStopSlice.setTimeStamp(data.timeStamp));
@@ -126,7 +126,7 @@ const FlowStopController = () => {
   const startExperiment = () => {
     // https://localhost:8001/FlowStopController/startFlowStopExperimentFastAPI?timeStamp=asdf&experimentName=adf&experimentDescription=asdf&uniqueId=asdf&numImages=19&volumePerImage=199&timeToStabilize=1&delayToStart=1&frameRate=1&filePath=.%2F&fileFormat=TIF&isRecordVideo=true&pumpSpeed=10000
     // Build URL from Redux connection settings
-    const url = `${hostIP}:${hostPort}/FlowStopController/startFlowStopExperimentFastAPI?timeStamp=${timeStamp}&experimentName=${experimentName}&experimentDescription=${experimentDescription}&uniqueId=${uniqueId}&numImages=${numImages}&volumePerImage=${volumePerImage}&timeToStabilize=${timeToStabilize}&isRecordVideo=true&pumpSpeed=${pumpSpeed}`;
+    const url = `${hostIP}:${hostPort}/imswitch/api/FlowStopController/startFlowStopExperimentFastAPI?timeStamp=${timeStamp}&experimentName=${experimentName}&experimentDescription=${experimentDescription}&uniqueId=${uniqueId}&numImages=${numImages}&volumePerImage=${volumePerImage}&timeToStabilize=${timeToStabilize}&isRecordVideo=true&pumpSpeed=${pumpSpeed}`;
     fetch(url, { method: "GET" })
       .then((response) => response.json())
       .then((data) => {
@@ -137,7 +137,7 @@ const FlowStopController = () => {
   };
 
   const stopExperiment = () => {
-    const url = `${hostIP}:${hostPort}/FlowStopController/stopFlowStopExperiment`;
+    const url = `${hostIP}:${hostPort}/imswitch/api/FlowStopController/stopFlowStopExperiment`;
 
     fetch(url, { method: "GET" })
       .then((response) => response.json())

--- a/src/components/GamepadSpeedControl.js
+++ b/src/components/GamepadSpeedControl.js
@@ -96,7 +96,7 @@ export default function GamepadSpeedControl({ hostIP, hostPort }) {
       });
 
       await fetch(
-        `${hostIP}:${hostPort}/PositionerController/movePositionerForever?${params}`
+        `${hostIP}:${hostPort}/imswitch/api/PositionerController/movePositionerForever?${params}`
       );
     } catch (error) {
       console.error(`Error sending movement command for ${axis}:`, error);

--- a/src/components/HoloController.js
+++ b/src/components/HoloController.js
@@ -107,7 +107,7 @@ const HoloController = () => {
   const processedImageRef = useRef(null);
 
   // Build stream URLs
-  const baseUrl = `${connectionSettings.ip}:${connectionSettings.apiPort}`;
+  const baseUrl = `${connectionSettings.ip}:${connectionSettings.apiPort}/imswitch/api`;
   const processedStreamUrl = `${baseUrl}/InLineHoloController/mjpeg_stream_inlineholo?startStream=true&jpeg_quality=85`;
 
   // Load initial parameters and state on mount

--- a/src/components/IlluminationController.js
+++ b/src/components/IlluminationController.js
@@ -58,7 +58,7 @@ export default function IlluminationController({ hostIP, hostPort }) {
     async function fetchIlluminationData() {
       try {
         // Fetch laser names
-        const namesRes = await fetch(`${hostIP}:${hostPort}/LaserController/getLaserNames`);
+        const namesRes = await fetch(`${hostIP}:${hostPort}/imswitch/api/LaserController/getLaserNames`);
         const names = await namesRes.json();
         dispatch(parameterRangeSlice.setIlluSources(names));
 
@@ -68,17 +68,17 @@ export default function IlluminationController({ hostIP, hostPort }) {
         for (const name of names) {
           const encodedName = encodeURIComponent(name);
           // Value range
-          const rangeRes = await fetch(`${hostIP}:${hostPort}/LaserController/getLaserValueRanges?laserName=${encodedName}`);
+          const rangeRes = await fetch(`${hostIP}:${hostPort}/imswitch/api/LaserController/getLaserValueRanges?laserName=${encodedName}`);
           const range = await rangeRes.json();
           minArr.push(range[0]);
           maxArr.push(range[1]);
           
           // Fetch initial laser state (power and active)
           try {
-            const valueRes = await fetch(`${hostIP}:${hostPort}/LaserController/getLaserValue?laserName=${encodedName}`);
+            const valueRes = await fetch(`${hostIP}:${hostPort}/imswitch/api/LaserController/getLaserValue?laserName=${encodedName}`);
             const power = await valueRes.json();
             
-            const activeRes = await fetch(`${hostIP}:${hostPort}/LaserController/getLaserActive?laserName=${encodedName}`);
+            const activeRes = await fetch(`${hostIP}:${hostPort}/imswitch/api/LaserController/getLaserActive?laserName=${encodedName}`);
             const enabled = await activeRes.json();
             
             // Initialize laser state in Redux
@@ -118,7 +118,7 @@ export default function IlluminationController({ hostIP, hostPort }) {
       if (ip && port) {
         try {
           const encodedLaserName = encodeURIComponent(laserName);
-          await fetch(`${ip}:${port}/LaserController/setLaserValue?laserName=${encodedLaserName}&value=${val}`);
+          await fetch(`${ip}:${port}/imswitch/api/LaserController/setLaserValue?laserName=${encodedLaserName}&value=${val}`);
           console.log(`${laserName} intensity updated to: ${val}`);
         } catch (error) {
           console.error("Failed to set laser value in backend:", error);
@@ -139,7 +139,7 @@ export default function IlluminationController({ hostIP, hostPort }) {
     if (ip && port) {
       try {
         const encodedLaserName = encodeURIComponent(laserName);
-        await fetch(`${ip}:${port}/LaserController/setLaserActive?laserName=${encodedLaserName}&active=${active}`);
+        await fetch(`${ip}:${port}/imswitch/api/LaserController/setLaserActive?laserName=${encodedLaserName}&active=${active}`);
         console.log(`${laserName} active state updated to: ${active}`);
       } catch (error) {
         console.error("Failed to set laser active state in backend:", error);

--- a/src/components/ImJoyView.js
+++ b/src/components/ImJoyView.js
@@ -51,7 +51,7 @@ const ImJoyView = ({ sharedImage }) => {
     if (!imjoyAPI) return;
     try {
       const response = await fetch(
-        `${hostIP}:${hostPort}/RecordingController/snapNumpyToFastAPI?resizeFactor=1`
+        `${hostIP}:${hostPort}/imswitch/api/RecordingController/snapNumpyToFastAPI?resizeFactor=1`
       );
       const arrayBuffer = await response.arrayBuffer();
       let ij = await imjoyAPI.getWindow("ImageJ.JS");

--- a/src/components/ImprovedAxisControl.jsx
+++ b/src/components/ImprovedAxisControl.jsx
@@ -52,7 +52,7 @@ const ImprovedAxisControl = ({ hostIP, hostPort }) => {
     (async () => {
       try {
         const r = await fetch(
-          `${hostIP}:${hostPort}/PositionerController/getPositionerNames`
+          `${hostIP}:${hostPort}/imswitch/api/PositionerController/getPositionerNames`
         );
         const d = await r.json();
         setPositionerName(d[0]);
@@ -86,7 +86,7 @@ const ImprovedAxisControl = ({ hostIP, hostPort }) => {
     }
   };
 
-  const base = `${hostIP}:${hostPort}/PositionerController`;
+  const base = `${hostIP}:${hostPort}/imswitch/api/PositionerController`;
 
   const moveAxis = (axis, distance) =>
     call(

--- a/src/components/JoystickControl.jsx
+++ b/src/components/JoystickControl.jsx
@@ -25,7 +25,7 @@ export default function JoystickControl({ hostIP, hostPort }) {
     (async () => {
       try {
         const r = await fetch(
-          `${hostIP}:${hostPort}/PositionerController/getPositionerNames`
+          `${hostIP}:${hostPort}/imswitch/api/PositionerController/getPositionerNames`
         );
         const d = await r.json();
         if (d && d.length > 0) {
@@ -40,7 +40,7 @@ export default function JoystickControl({ hostIP, hostPort }) {
   // Joystick movement functions
   const moveJoystickStage = (axis, distance) => {
     fetch(
-      `${hostIP}:${hostPort}/PositionerController/movePositioner?axis=${axis}&dist=${distance}&isAbsolute=false&isBlocking=false`
+      `${hostIP}:${hostPort}/imswitch/api/PositionerController/movePositioner?axis=${axis}&dist=${distance}&isAbsolute=false&isBlocking=false`
     )
       .then((res) => res.json())
       .catch(console.error);
@@ -52,7 +52,7 @@ export default function JoystickControl({ hostIP, hostPort }) {
       return;
     }
     fetch(
-      `${hostIP}:${hostPort}/PositionerController/homeAxis?positionerName=${positionerName}&axis=${axis}&isBlocking=false`
+      `${hostIP}:${hostPort}/imswitch/api/PositionerController/homeAxis?positionerName=${positionerName}&axis=${axis}&isBlocking=false`
     )
       .then((res) => res.json())
       .catch(console.error);

--- a/src/components/JoystickController.js
+++ b/src/components/JoystickController.js
@@ -28,7 +28,7 @@ const JoystickController = ({ hostIP, hostPort }) => {
   // Movement functions
   const moveStage = (axis, distance) => {
     fetch(
-      `${hostIP}:${hostPort}/PositionerController/movePositioner?axis=${axis}&dist=${distance}&isAbsolute=false&isBlocking=false`
+      `${hostIP}:${hostPort}/imswitch/api/PositionerController/movePositioner?axis=${axis}&dist=${distance}&isAbsolute=false&isBlocking=false`
     )
       .then((res) => res.json())
       .catch(console.error);
@@ -37,7 +37,7 @@ const JoystickController = ({ hostIP, hostPort }) => {
   const homeAxis = (axis) => {
     // Using a homing command - this may need adjustment based on your API
     fetch(
-      `${hostIP}:${hostPort}/PositionerController/movePositioner?axis=${axis}&dist=0&isAbsolute=true&isBlocking=false`
+      `${hostIP}:${hostPort}/imswitch/api/PositionerController/movePositioner?axis=${axis}&dist=0&isAbsolute=true&isBlocking=false`
     )
       .then((res) => res.json())
       .catch(console.error);

--- a/src/components/JupyterExecutor.js
+++ b/src/components/JupyterExecutor.js
@@ -14,7 +14,7 @@ const JupyterExecutor = () => {
     const fetchNotebookUrl = async () => {
       try {
         const response = await fetch(
-          `${hostIP}:${hostPort}/jupyternotebookurl`
+          `${hostIP}:${hostPort}/imswitch/api/jupyternotebookurl`
         );
         const data = await response.json();
         const notebookUrl = data["url"];

--- a/src/components/LepmonController.js
+++ b/src/components/LepmonController.js
@@ -76,19 +76,19 @@ export default function LepmonController() {
     async function fetchInitialData() {
       try {
         // Build base URL from Redux state
-        const urlStatus = `${hostIP}:${hostPort}/LepmonController/getStatus`;
+        const urlStatus = `${hostIP}:${hostPort}/imswitch/api/LepmonController/getStatus`;
         const resStatus = await fetch(urlStatus);
         const statusData = await resStatus.json();
         dispatch(lepmonSlice.setInitialStatus(statusData));
 
         // 2. Hole Kamera-/Timelapse-Einstellungen
-        const urlInitialParams = `${hostIP}:${hostPort}/LepmonController/getInitialParams`;
+        const urlInitialParams = `${hostIP}:${hostPort}/imswitch/api/LepmonController/getInitialParams`;
         const resParams = await fetch(urlInitialParams);
         const paramsData = await resParams.json();
         dispatch(lepmonSlice.setInitialParams(paramsData));
 
         // 3. Hole Hardware-Status (new)
-        const urlHardwareStatus = `${hostIP}:${hostPort}/LepmonController/getHardwareStatus`;
+        const urlHardwareStatus = `${hostIP}:${hostPort}/imswitch/api/LepmonController/getHardwareStatus`;
         const resHardware = await fetch(urlHardwareStatus);
         const hardwareData = await resHardware.json();
         dispatch(lepmonSlice.setHardwareStatus(hardwareData.hardwareStatus));
@@ -101,7 +101,7 @@ export default function LepmonController() {
         dispatch(lepmonSlice.setLcdDisplay(hardwareData.lcdDisplay));
 
         // 4. Hole Timing-Konfiguration (new)
-        const urlTimingConfig = `${hostIP}:${hostPort}/LepmonController/getTimingConfig`;
+        const urlTimingConfig = `${hostIP}:${hostPort}/imswitch/api/LepmonController/getTimingConfig`;
         const resTiming = await fetch(urlTimingConfig);
         const timingData = await resTiming.json();
         dispatch(lepmonSlice.setTimingConfig(timingData));
@@ -290,7 +290,7 @@ export default function LepmonController() {
     });
 
     try {
-      const urlStart = `${hostIP}:${hostPort}/LepmonController/startExperiment?${params.toString()}`;
+      const urlStart = `${hostIP}:${hostPort}/imswitch/api/LepmonController/startExperiment?${params.toString()}`;
       const res = await fetch(urlStart, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -306,7 +306,7 @@ export default function LepmonController() {
 
   const handleStop = async () => {
     try {
-      const urlStop = `${hostIP}:${hostPort}/LepmonController/stopLepmonExperiment`;
+      const urlStop = `${hostIP}:${hostPort}/imswitch/api/LepmonController/stopLepmonExperiment`;
       const res = await fetch(urlStop, { method: "POST" });
       const data = await res.json();
       if (data.success) {
@@ -320,7 +320,7 @@ export default function LepmonController() {
   // Fokusmodus
   const handleFocus = async () => {
     try {
-      const urlFocus = `${hostIP}:${hostPort}/LepmonController/focusMode`;
+      const urlFocus = `${hostIP}:${hostPort}/imswitch/api/LepmonController/focusMode`;
       await fetch(urlFocus, { method: "POST" });
       // Backend startet 15s-Fokusmodus => sendet "focusSharpness" als WS
     } catch (err) {
@@ -332,7 +332,7 @@ export default function LepmonController() {
   const handleReboot = async () => {
     // z. B. mit Confirm-Dialog
     try {
-      const urlReboot = `${hostIP}:${hostPort}/LepmonController/reboot`;
+      const urlReboot = `${hostIP}:${hostPort}/imswitch/api/LepmonController/reboot`;
       await fetch(urlReboot, { method: "POST" });
     } catch (err) {
       console.error("Reboot-Error:", err);
@@ -348,7 +348,7 @@ export default function LepmonController() {
         lightName: lightName,
         state: newState,
       });
-      const url = `${hostIP}:${hostPort}/LepmonController/setLightState?${params.toString()}`;
+      const url = `${hostIP}:${hostPort}/imswitch/api/LepmonController/setLightState?${params.toString()}`;
       const response = await fetch(url, {
         method: "POST",
       });
@@ -367,7 +367,7 @@ export default function LepmonController() {
       const params = new URLSearchParams({
         state: newState,
       });
-      const url = `${hostIP}:${hostPort}/LepmonController/setAllLightsState?${params.toString()}`;
+      const url = `${hostIP}:${hostPort}/imswitch/api/LepmonController/setAllLightsState?${params.toString()}`;
       const response = await fetch(url, {
         method: "POST",
       });
@@ -388,7 +388,7 @@ export default function LepmonController() {
   // Snap Image Function (new)
   const handleSnapImage = async () => {
     try {
-      const url = `${hostIP}:${hostPort}/LepmonController/lepmonSnapImage`;
+      const url = `${hostIP}:${hostPort}/imswitch/api/LepmonController/lepmonSnapImage`;
       const response = await fetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -406,7 +406,7 @@ export default function LepmonController() {
   // Update LCD Display Function (new)
   const handleUpdateDisplay = async (line1, line2, line3, line4) => {
     try {
-      const url = `${hostIP}:${hostPort}/LepmonController/updateLCDDisplay`;
+      const url = `${hostIP}:${hostPort}/imswitch/api/LepmonController/updateLCDDisplay`;
       const response = await fetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -424,7 +424,7 @@ export default function LepmonController() {
   // Timing Configuration Update Function (new)
   const handleTimingConfigUpdate = async (newConfig) => {
     try {
-      const url = `${hostIP}:${hostPort}/LepmonController/setTimingConfig`;
+      const url = `${hostIP}:${hostPort}/imswitch/api/LepmonController/setTimingConfig`;
       const response = await fetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -442,7 +442,7 @@ export default function LepmonController() {
   // LepmonOS Control Functions (new)
   const handleLepmonStartup = async () => {
     try {
-      const url = `${hostIP}:${hostPort}/LepmonController/lepmonStartup`;
+      const url = `${hostIP}:${hostPort}/imswitch/api/LepmonController/lepmonStartup`;
       const response = await fetch(url, { method: "POST" });
       const data = await response.json();
       if (data.success) {
@@ -455,7 +455,7 @@ export default function LepmonController() {
 
   const handleLepmonShutdown = async () => {
     try {
-      const url = `${hostIP}:${hostPort}/LepmonController/lepmonShutdown`;
+      const url = `${hostIP}:${hostPort}/imswitch/api/LepmonController/lepmonShutdown`;
       const response = await fetch(url, { method: "POST" });
       const data = await response.json();
       if (data.success) {
@@ -470,7 +470,7 @@ export default function LepmonController() {
   const handleUVLedControl = async (action) => {
     try {
       const params = new URLSearchParams({ action });
-      const url = `${hostIP}:${hostPort}/LepmonController/lepmonUVLed?${params.toString()}`;
+      const url = `${hostIP}:${hostPort}/imswitch/api/LepmonController/lepmonUVLed?${params.toString()}`;
       const response = await fetch(url, {
         method: "POST",
       });
@@ -489,7 +489,7 @@ export default function LepmonController() {
   const handleVisibleLedControl = async (action) => {
     try {
       const params = new URLSearchParams({ action });
-      const url = `${hostIP}:${hostPort}/LepmonController/lepmonVisibleLed?${params.toString()}`;
+      const url = `${hostIP}:${hostPort}/imswitch/api/LepmonController/lepmonVisibleLed?${params.toString()}`;
       const response = await fetch(url, {
         method: "POST",
       });
@@ -510,7 +510,7 @@ export default function LepmonController() {
   // Live Sensor Data Fetch (new)
   const fetchLiveSensorData = async () => {
     try {
-      const url = `${hostIP}:${hostPort}/LepmonController/getSensorDataLive`;
+      const url = `${hostIP}:${hostPort}/imswitch/api/LepmonController/getSensorDataLive`;
       const response = await fetch(url);
       const data = await response.json();
       if (data.success) {

--- a/src/components/LightsheetController.jsx
+++ b/src/components/LightsheetController.jsx
@@ -174,7 +174,7 @@ const LightsheetController = () => {
     // Build socket URL
     const socketUrl = `${hostIP}:${hostPort}`;
     const socket = io(socketUrl, {
-      path: '/imswitch/socket.io',
+      path: '/imswitch/socket.io/',
       transports: ['websocket', 'polling'],
       reconnection: true,
       reconnectionAttempts: 5,

--- a/src/components/LightsheetController.jsx
+++ b/src/components/LightsheetController.jsx
@@ -174,7 +174,7 @@ const LightsheetController = () => {
     // Build socket URL
     const socketUrl = `${hostIP}:${hostPort}`;
     const socket = io(socketUrl, {
-      path: '/socket.io',
+      path: '/imswitch/socket.io',
       transports: ['websocket', 'polling'],
       reconnection: true,
       reconnectionAttempts: 5,
@@ -205,7 +205,7 @@ const LightsheetController = () => {
   // Set up observation stream URL
   useEffect(() => {
     if (hostIP && hostPort) {
-      setObservationStreamUrl(`${hostIP}:${hostPort}/LightsheetController/observationStream`);
+      setObservationStreamUrl(`${hostIP}:${hostPort}/imswitch/api/LightsheetController/observationStream`);
     }
   }, [hostIP, hostPort]);
 
@@ -1085,7 +1085,7 @@ const LightsheetController = () => {
                   startIcon={<StopIcon />}
                   onClick={() => {
                     // TODO: Implement stop functionality via API
-                    fetch(`${hostIP}:${hostPort}/LightsheetController/stopLightsheet`);
+                    fetch(`${hostIP}:${hostPort}/imswitch/api/LightsheetController/stopLightsheet`);
                   }}
                 >
                   Stop
@@ -1480,7 +1480,7 @@ const LightsheetController = () => {
                 const phase = lightsheetState.galvoPhase || 0;
                 const invert = lightsheetState.galvoInvert || 1;
 
-                const url = `${hostIP}:${hostPort}/LightsheetController/setGalvo?channel=${channel}&frequency=${frequency}&offset=${offset}&amplitude=${amplitude}&clk_div=${clk_div}&phase=${phase}&invert=${invert}`;
+                const url = `${hostIP}:${hostPort}/imswitch/api/LightsheetController/setGalvo?channel=${channel}&frequency=${frequency}&offset=${offset}&amplitude=${amplitude}&clk_div=${clk_div}&phase=${phase}&invert=${invert}`;
 
                 fetch(url, { method: "GET" })
                   .then((response) => response.json())
@@ -1514,7 +1514,7 @@ const LightsheetController = () => {
               startIcon={<ViewInArIcon />}
               onClick={() =>
                 window.open(
-                  `https://kitware.github.io/itk-vtk-viewer/app/?rotate=false&fileToLoad=${hostIP}:${hostPort}/LightsheetController/getLatestLightsheetStackAsTif`,
+                  `https://kitware.github.io/itk-vtk-viewer/app/?rotate=false&fileToLoad=${hostIP}:${hostPort}/imswitch/api/LightsheetController/getLatestLightsheetStackAsTif`,
                   "_blank"
                 )
               }
@@ -1529,7 +1529,7 @@ const LightsheetController = () => {
               startIcon={<DownloadIcon />}
               onClick={() =>
                 window.open(
-                  `${hostIP}:${hostPort}/LightsheetController/getLatestLightsheetStackAsTif`,
+                  `${hostIP}:${hostPort}/imswitch/api/LightsheetController/getLatestLightsheetStackAsTif`,
                   "_blank"
                 )
               }
@@ -1614,7 +1614,7 @@ const LightsheetController = () => {
             VTK Volume Viewer (TIFF)
           </Typography>
           <VtkViewer
-            tifUrl={`${hostIP}:${hostPort}/LightsheetController/getLatestLightsheetStackAsTif`}
+            tifUrl={`${hostIP}:${hostPort}/imswitch/api/LightsheetController/getLatestLightsheetStackAsTif`}
           />
         </ErrorBoundary>
       </TabPanel>

--- a/src/components/LiveView.js
+++ b/src/components/LiveView.js
@@ -105,7 +105,7 @@ export default function LiveView({ setFileManagerInitialPath }) {
       try {
         // 'getDetectorNames' must return something array-like
         const r = await fetch(
-          `${hostIP}:${hostPort}/SettingsController/getDetectorNames`
+          `${hostIP}:${hostPort}/imswitch/api/SettingsController/getDetectorNames`
         );
         const data = await r.json();
         // Check if data is an array before setting state
@@ -129,7 +129,7 @@ export default function LiveView({ setFileManagerInitialPath }) {
     (async () => {
       try {
         const r = await fetch(
-          `${hostIP}:${hostPort}/HistogrammController/minmaxvalues`
+          `${hostIP}:${hostPort}/imswitch/api/HistogrammController/minmaxvalues`
         );
         if (!r.ok) return;
         const d = await r.json();
@@ -147,7 +147,7 @@ export default function LiveView({ setFileManagerInitialPath }) {
       const id = setInterval(async () => {
         try {
           const res = await fetch(
-            `${hostIP}:${hostPort}/HistoScanController/getPreviewCameraImage?resizeFactor=.25`
+            `${hostIP}:${hostPort}/imswitch/api/HistoScanController/getPreviewCameraImage?resizeFactor=.25`
           );
           if (res.ok)
             dispatch(
@@ -233,7 +233,7 @@ export default function LiveView({ setFileManagerInitialPath }) {
   async function snap(fileName, format) {
     // English comment: Example fetch for snapping an image with editable fileName
     const response = await fetch(
-      `${hostIP}:${hostPort}/RecordingController/snapImageToPath?fileName=${fileName}&mSaveFormat=${format}`
+      `${hostIP}:${hostPort}/imswitch/api/RecordingController/snapImageToPath?fileName=${fileName}&mSaveFormat=${format}`
     );
     const data = await response.json();
     // data.relativePath might be "recordings/2025_05_20-11-12-44_PM"
@@ -248,12 +248,12 @@ export default function LiveView({ setFileManagerInitialPath }) {
   const startRec = async (format) => {
     setIsRecording(true);
     fetch(
-      `${hostIP}:${hostPort}/RecordingController/startRecording?mSaveFormat=${format}`
+      `${hostIP}:${hostPort}/imswitch/api/RecordingController/startRecording?mSaveFormat=${format}`
     ).catch(() => {});
   };
   const stopRec = async () => {
     setIsRecording(false);
-    fetch(`${hostIP}:${hostPort}/RecordingController/stopRecording`).catch(
+    fetch(`${hostIP}:${hostPort}/imswitch/api/RecordingController/stopRecording`).catch(
       () => {}
     );
   };

--- a/src/components/LiveViewSettings.js
+++ b/src/components/LiveViewSettings.js
@@ -38,7 +38,7 @@ const LiveViewSettings = () => {
       if (connectionSettingsState.ip && connectionSettingsState.apiPort) {
         try {
           const response = await fetch(
-            `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/SettingsController/getDetectorParameters`
+            `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/imswitch/api/SettingsController/getDetectorParameters`
           );
           if (response.ok) {
             const data = await response.json();
@@ -78,7 +78,7 @@ const LiveViewSettings = () => {
                 try {
                   const encodedLaserName = encodeURIComponent(laserName);
                   const response = await fetch(
-                    `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/LaserController/getLaserValue?laserName=${encodedLaserName}`
+                    `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/imswitch/api/LaserController/getLaserValue?laserName=${encodedLaserName}`
                   );
                   
                   if (response.ok) {
@@ -152,7 +152,7 @@ const LiveViewSettings = () => {
     if (connectionSettingsState.ip && connectionSettingsState.apiPort) {
       try {
         await fetch(
-          `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/SettingsController/setDetectorExposureTime?exposureTime=${newValue}`
+          `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/imswitch/api/SettingsController/setDetectorExposureTime?exposureTime=${newValue}`
         );
       } catch (error) {
         console.error("Failed to update exposure time in backend:", error);
@@ -169,7 +169,7 @@ const LiveViewSettings = () => {
       try {
         const encodedLaserName = encodeURIComponent(laserName);
         await fetch(
-          `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/LaserController/setLaserValue?laserName=${encodedLaserName}&value=${value}`
+          `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/imswitch/api/LaserController/setLaserValue?laserName=${encodedLaserName}&value=${value}`
         );
       } catch (error) {
         console.error("Failed to update laser intensity in backend:", error);
@@ -186,7 +186,7 @@ const LiveViewSettings = () => {
       try {
         const encodedLaserName = encodeURIComponent(laserName);
         await fetch(
-          `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/LaserController/setLaserActive?laserName=${encodedLaserName}&active=${active}`
+          `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/imswitch/api/LaserController/setLaserActive?laserName=${encodedLaserName}&active=${active}`
         );
       } catch (error) {
         console.error("Failed to update laser active state in backend:", error);
@@ -202,7 +202,7 @@ const LiveViewSettings = () => {
     if (connectionSettingsState.ip && connectionSettingsState.apiPort) {
       try {
         await fetch(
-          `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/SettingsController/setDetectorGain?gain=${value}`
+          `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/imswitch/api/SettingsController/setDetectorGain?gain=${value}`
         );
       } catch (error) {
         console.error("Failed to update detector gain in backend:", error);

--- a/src/components/LoggingController.jsx
+++ b/src/components/LoggingController.jsx
@@ -48,7 +48,7 @@ export default function LoggingController() {
   const [error, setError] = useState(null);
   const [selectedFile, setSelectedFile] = useState(null);
 
-  const baseUrl = `${hostIP}:${hostPort}`;
+  const baseUrl = `${hostIP}:${hostPort}/imswitch/api`;
 
   /**
    * Fetch the list of log files from the backend

--- a/src/components/MCTController.js
+++ b/src/components/MCTController.js
@@ -82,7 +82,7 @@ const MCTController = ({ hostIP, hostPort }) => {
   */
   useEffect(() => {
     const fetchMCTStatus = () => {
-      const url = `${hostIP}:${hostPort}/MCTController/getMCTStatus`;
+      const url = `${hostIP}:${hostPort}/imswitch/api/MCTController/getMCTStatus`;
 
   
       fetch(url)
@@ -126,7 +126,7 @@ const MCTController = ({ hostIP, hostPort }) => {
   
   const handleStart = () => {
     const url =
-      `${hostIP}:${hostPort}/MCTController/startTimelapseImaging?` +
+      `${hostIP}:${hostPort}/imswitch/api/MCTController/startTimelapseImaging?` +
       `tperiod=${timePeriod}&nImagesToCapture=${numMeasurements}&MCTFilename=${fileName}&` +
       `zStackEnabled=${zStackEnabled}&zStackMin=${zMin}&zStackMax=${zMax}&zStackStep=${zSteps}&` +
       `xyScanEnabled=${xStackEnabled}&xScanMin=${xMin}&xScanMax=${xMax}&xScanStep=${xSteps}&` +
@@ -143,7 +143,7 @@ const MCTController = ({ hostIP, hostPort }) => {
   };
 
   const handleStop = () => {
-    const url = `${hostIP}:${hostPort}/MCTController/stopTimelapseImaging`;
+    const url = `${hostIP}:${hostPort}/imswitch/api/MCTController/stopTimelapseImaging`;
     fetch(url, { method: "GET" })
       .then((response) => response.json())
       .then((data) => {

--- a/src/components/OpenLayers.js
+++ b/src/components/OpenLayers.js
@@ -29,7 +29,7 @@ const OpenLayersComponent = () => {
       minZoom: 5,
     });
 
-    const urlTemplate = `${hostIP}:${hostPort}/HistoScanController/get_tile?z={z}&x={x}&y={y}`;
+    const urlTemplate = `${hostIP}:${hostPort}/imswitch/api/HistoScanController/get_tile?z={z}&x={x}&y={y}`;
 
     const tileLayer = new TileLayer({
       source: new XYZ({
@@ -39,7 +39,7 @@ const OpenLayersComponent = () => {
         tileUrlFunction: (tileCoord) => {
           console.log("Resolutions:", tileGrid.getResolutions());
           const [z, x, y] = tileCoord;
-          return `${hostIP}:${hostPort}/...&z=${z}&x=${x}&y=${y}`;
+          return `${hostIP}:${hostPort}/imswitch/api/...&z=${z}&x=${x}&y=${y}`;
         },
       }),
     });

--- a/src/components/PreviewWidget.js
+++ b/src/components/PreviewWidget.js
@@ -3,7 +3,7 @@ import { Paper, Typography, Slider, TextField, Switch } from '@mui/material';
 
 const PreviewWidget = ({ hostIP, hostPort, title }) => {
     const videoRef = useRef(null);
-    const streamUrl = `${hostIP}:${hostPort}/RecordingController/video_feeder`
+    const streamUrl = `${hostIP}:${hostPort}/imswitch/api/RecordingController/video_feeder`
     // simply display the stream from the camera under 
     return (
         <img

--- a/src/components/STORMController.js
+++ b/src/components/STORMController.js
@@ -138,7 +138,7 @@ const STORMController = ({ hostIP, hostPort, WindowTitle }) => {
         // Try to get a snapshot from the backend for initial cropping
         try {
           const response = await fetch(
-            `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/DetectorController/getLatestDetectorFrame`
+            `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/imswitch/api/DetectorController/getLatestDetectorFrame`
           );
           if (response.ok) {
             const blob = await response.blob();
@@ -162,7 +162,7 @@ const STORMController = ({ hostIP, hostPort, WindowTitle }) => {
       if (connectionSettingsState.ip && connectionSettingsState.apiPort) {
         try {
           const response = await fetch(
-            `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/SettingsController/getDetectorParameters`
+            `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/imswitch/api/SettingsController/getDetectorParameters`
           );
           if (response.ok) {
             const data = await response.json();
@@ -251,7 +251,7 @@ const STORMController = ({ hostIP, hostPort, WindowTitle }) => {
                 try {
                   const encodedLaserName = encodeURIComponent(laserName);
                   const response = await fetch(
-                    `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/LaserController/getLaserValue?laserName=${encodedLaserName}`
+                    `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/imswitch/api/LaserController/getLaserValue?laserName=${encodedLaserName}`
                   );
                   
                   if (response.ok) {
@@ -391,7 +391,7 @@ const STORMController = ({ hostIP, hostPort, WindowTitle }) => {
     if (connectionSettingsState.ip && connectionSettingsState.apiPort) {
       try {
         await fetch(
-          `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/SettingsController/setDetectorExposureTime?exposureTime=${newValue}`
+          `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/imswitch/api/SettingsController/setDetectorExposureTime?exposureTime=${newValue}`
         );
       } catch (error) {
         console.error("Failed to update exposure time in backend:", error);
@@ -408,7 +408,7 @@ const STORMController = ({ hostIP, hostPort, WindowTitle }) => {
       try {
         const encodedLaserName = encodeURIComponent(laserName);
         await fetch(
-          `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/LaserController/setLaserValue?laserName=${encodedLaserName}&value=${value}`
+          `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/imswitch/api/LaserController/setLaserValue?laserName=${encodedLaserName}&value=${value}`
         );
       } catch (error) {
         console.error("Failed to update laser intensity in backend:", error);
@@ -425,7 +425,7 @@ const STORMController = ({ hostIP, hostPort, WindowTitle }) => {
       try {
         const encodedLaserName = encodeURIComponent(laserName);
         await fetch(
-          `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/LaserController/setLaserActive?laserName=${encodedLaserName}&active=${active}`
+          `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/imswitch/api/LaserController/setLaserActive?laserName=${encodedLaserName}&active=${active}`
         );
       } catch (error) {
         console.error("Failed to update laser active state in backend:", error);
@@ -441,7 +441,7 @@ const STORMController = ({ hostIP, hostPort, WindowTitle }) => {
     if (connectionSettingsState.ip && connectionSettingsState.apiPort) {
       try {
         await fetch(
-          `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/SettingsController/setDetectorGain?gain=${value}`
+          `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/imswitch/api/SettingsController/setDetectorGain?gain=${value}`
         );
       } catch (error) {
         console.error("Failed to update detector gain in backend:", error);
@@ -484,7 +484,7 @@ const STORMController = ({ hostIP, hostPort, WindowTitle }) => {
   const handleLoadImage = async () => {
     try {
       const response = await fetch(
-        `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/RecordingController/snapNumpyToFastAPI?resizeFactor=1`
+        `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/imswitch/api/RecordingController/snapNumpyToFastAPI?resizeFactor=1`
       );
       if (!response.ok) throw new Error("Failed to load image");
       const blob = await response.blob();
@@ -689,7 +689,7 @@ const STORMController = ({ hostIP, hostPort, WindowTitle }) => {
       const imagePath = await apiSTORMControllerGetLastReconstructedImagePath();
       if (imagePath && connectionSettingsState.ip && connectionSettingsState.apiPort) {
         // Construct the URL to load the image
-        const imageUrl = `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/FileManager/preview/${encodeURIComponent(imagePath)}`;
+        const imageUrl = `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/imswitch/api/FileManager/preview/${encodeURIComponent(imagePath)}`;
         dispatch(stormSlice.setReconstructedImage(imageUrl));
       }
     } catch (error) {

--- a/src/components/STORMControllerArkitekt.js
+++ b/src/components/STORMControllerArkitekt.js
@@ -128,7 +128,7 @@ const STORMControllerArkitekt = () => {
   const connectToArkitekt = async () => {
     try {
       const response = await fetch(
-        `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/ArkitektController/connect`
+        `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/imswitch/api/ArkitektController/connect`
       );
       if (response.ok) {
         setArkitektConnected(true);
@@ -142,7 +142,7 @@ const STORMControllerArkitekt = () => {
   const loadAvailableWorkflows = async () => {
     try {
       const response = await fetch(
-        `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/ArkitektController/getWorkflows`
+        `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/imswitch/api/ArkitektController/getWorkflows`
       );
       if (response.ok) {
         const workflows = await response.json();
@@ -156,7 +156,7 @@ const STORMControllerArkitekt = () => {
   const startArkitektProcessing = async () => {
     try {
       const response = await fetch(
-        `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/ArkitektController/startWorkflow`,
+        `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/imswitch/api/ArkitektController/startWorkflow`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -177,7 +177,7 @@ const STORMControllerArkitekt = () => {
   const stopArkitektProcessing = async () => {
     try {
       const response = await fetch(
-        `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/ArkitektController/stopWorkflow`,
+        `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/imswitch/api/ArkitektController/stopWorkflow`,
         { method: "POST" }
       );
       if (response.ok) {

--- a/src/components/STORMControllerLocal.js
+++ b/src/components/STORMControllerLocal.js
@@ -242,7 +242,7 @@ const STORMControllerLocal = () => {
   const handleLoadImage = async () => {
     try {
       const response = await fetch(
-        `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/RecordingController/snapNumpyToFastAPI?resizeFactor=1`
+        `${connectionSettingsState.ip}:${connectionSettingsState.apiPort}/imswitch/api/RecordingController/snapNumpyToFastAPI?resizeFactor=1`
       );
       if (!response.ok) throw new Error("Failed to load image");
       const blob = await response.blob();

--- a/src/components/SelectSetupController.js
+++ b/src/components/SelectSetupController.js
@@ -45,7 +45,7 @@ const SelectSetupController = ({ hostIP, hostPort }) => {
   const isRestarting = uc2State.isRestarting;
 
   const fetchCurrentActiveFilename = useCallback(() => {
-    const url = `${hostIP}:${hostPort}/UC2ConfigController/getCurrentSetupFilename`;
+    const url = `${hostIP}:${hostPort}/imswitch/api/UC2ConfigController/getCurrentSetupFilename`;
     dispatch(uc2Slice.setIsLoadingCurrentFilename(true));
     
     fetch(url)
@@ -88,7 +88,7 @@ const SelectSetupController = ({ hostIP, hostPort }) => {
   }, [hostIP, hostPort, dispatch]);
 
   const fetchAvailableSetups = useCallback(() => {
-    const url = `${hostIP}:${hostPort}/UC2ConfigController/returnAvailableSetups`;
+    const url = `${hostIP}:${hostPort}/imswitch/api/UC2ConfigController/returnAvailableSetups`;
     dispatch(
       setNotification({
         message: "Loading available setups...",
@@ -127,7 +127,7 @@ const SelectSetupController = ({ hostIP, hostPort }) => {
     const maxRetries = 30; // 5 minutes with 10-second intervals
 
     const checkStatus = () => {
-      fetch(`${hostIP}:${hostPort}/UC2ConfigController/is_connected`)
+      fetch(`${hostIP}:${hostPort}/imswitch/api/UC2ConfigController/is_connected`)
         .then((res) => res.json())
         .then((data) => {
           if (data === true) {
@@ -207,7 +207,7 @@ const SelectSetupController = ({ hostIP, hostPort }) => {
       })
     );
 
-    const url = `${hostIP}:${hostPort}/UC2ConfigController/setSetupFileName?setupFileName=${encodeURIComponent(
+    const url = `${hostIP}:${hostPort}/imswitch/api/UC2ConfigController/setSetupFileName?setupFileName=${encodeURIComponent(
       selectedSetup
     )}&restartSoftware=${restartSoftware}`;
 

--- a/src/components/SerialDebugController.jsx
+++ b/src/components/SerialDebugController.jsx
@@ -40,7 +40,7 @@ const SerialDebugController = () => {
   const handleSendSerial = () => {
     if (!serialPayload?.trim()) return;
 
-    const url = `${hostIP}:${hostPort}/UC2ConfigController/writeSerial?payload=${encodeURIComponent(
+    const url = `${hostIP}:${hostPort}/imswitch/api/UC2ConfigController/writeSerial?payload=${encodeURIComponent(
       serialPayload
     )}`;
 

--- a/src/components/StageOffsetCalibrationController.jsx
+++ b/src/components/StageOffsetCalibrationController.jsx
@@ -55,7 +55,7 @@ const StageOffsetCalibration = () => {
     const fetchPositionerName = async () => {
       try {
         const response = await fetch(
-          `${hostIP}:${hostPort}/PositionerController/getPositionerNames`
+          `${hostIP}:${hostPort}/imswitch/api/PositionerController/getPositionerNames`
         );
         const data = await response.json();
         if (data && data.length > 0) {
@@ -74,7 +74,7 @@ const StageOffsetCalibration = () => {
       try {
         // Fetch current offsets
         const offsetXData = await fetch(
-          `${hostIP}:${hostPort}/PositionerController/getStageOffsetAxis?axis=X`
+          `${hostIP}:${hostPort}/imswitch/api/PositionerController/getStageOffsetAxis?axis=X`
         ).then((res) => res.json());
         dispatch(
           stageOffsetCalibrationSlice.setLoadedOffsetX(
@@ -83,7 +83,7 @@ const StageOffsetCalibration = () => {
         );
 
         const offsetYData = await fetch(
-          `${hostIP}:${hostPort}/PositionerController/getStageOffsetAxis?axis=Y`
+          `${hostIP}:${hostPort}/imswitch/api/PositionerController/getStageOffsetAxis?axis=Y`
         ).then((res) => res.json());
         dispatch(
           stageOffsetCalibrationSlice.setLoadedOffsetY(
@@ -93,7 +93,7 @@ const StageOffsetCalibration = () => {
 
         // Fetch true positions (without offset)
         const truePosXData = await fetch(
-          `${hostIP}:${hostPort}/PositionerController/getTruePositionerPositionWithoutOffset?axis=X`
+          `${hostIP}:${hostPort}/imswitch/api/PositionerController/getTruePositionerPositionWithoutOffset?axis=X`
         ).then((res) => res.json());
         dispatch(
           stageOffsetCalibrationSlice.setCurrentX(
@@ -102,7 +102,7 @@ const StageOffsetCalibration = () => {
         );
 
         const truePosYData = await fetch(
-          `${hostIP}:${hostPort}/PositionerController/getTruePositionerPositionWithoutOffset?axis=Y`
+          `${hostIP}:${hostPort}/imswitch/api/PositionerController/getTruePositionerPositionWithoutOffset?axis=Y`
         ).then((res) => res.json());
         dispatch(
           stageOffsetCalibrationSlice.setCurrentY(
@@ -121,7 +121,7 @@ const StageOffsetCalibration = () => {
     const interval = setInterval(async () => {
       try {
         const truePosXData = await fetch(
-          `${hostIP}:${hostPort}/PositionerController/getTruePositionerPositionWithoutOffset?axis=X`
+          `${hostIP}:${hostPort}/imswitch/api/PositionerController/getTruePositionerPositionWithoutOffset?axis=X`
         ).then((res) => res.json());
         dispatch(
           stageOffsetCalibrationSlice.setCurrentX(
@@ -130,7 +130,7 @@ const StageOffsetCalibration = () => {
         );
 
         const truePosYData = await fetch(
-          `${hostIP}:${hostPort}/PositionerController/getTruePositionerPositionWithoutOffset?axis=Y`
+          `${hostIP}:${hostPort}/imswitch/api/PositionerController/getTruePositionerPositionWithoutOffset?axis=Y`
         ).then((res) => res.json());
         dispatch(
           stageOffsetCalibrationSlice.setCurrentY(
@@ -148,7 +148,7 @@ const StageOffsetCalibration = () => {
   // Move stage
   const moveStage = (axis, distance) => {
     fetch(
-      `${hostIP}:${hostPort}/PositionerController/movePositioner?axis=${axis}&dist=${distance}&isAbsolute=false&isBlocking=false`
+      `${hostIP}:${hostPort}/imswitch/api/PositionerController/movePositioner?axis=${axis}&dist=${distance}&isAbsolute=false&isBlocking=false`
     )
       .then((res) => res.json())
       .catch(console.error);
@@ -182,7 +182,7 @@ const StageOffsetCalibration = () => {
       return;
     }
     fetch(
-      `${hostIP}:${hostPort}/PositionerController/setStageOffsetAxis?knownOffset=${offset}&axis=${axis}`
+      `${hostIP}:${hostPort}/imswitch/api/PositionerController/setStageOffsetAxis?knownOffset=${offset}&axis=${axis}`
     )
       .then((res) => res.json())
       .then(() => {
@@ -200,7 +200,7 @@ const StageOffsetCalibration = () => {
       return;
     }
     fetch(
-      `${hostIP}:${hostPort}/PositionerController/setStageOffsetAxis?knownPosition=${knownPos}&axis=${axis}`
+      `${hostIP}:${hostPort}/imswitch/api/PositionerController/setStageOffsetAxis?knownPosition=${knownPos}&axis=${axis}`
     )
       .then((res) => res.json())
       .then(() => {
@@ -213,7 +213,7 @@ const StageOffsetCalibration = () => {
   // Reset offset for a specific axis
   const resetStageOffset = (axis) => {
     fetch(
-      `${hostIP}:${hostPort}/PositionerController/resetStageOffsetAxis?axis=${axis}`
+      `${hostIP}:${hostPort}/imswitch/api/PositionerController/resetStageOffsetAxis?axis=${axis}`
     )
       .then((res) => res.json())
       .then(() => {

--- a/src/components/StreamControlOverlay.js
+++ b/src/components/StreamControlOverlay.js
@@ -1223,7 +1223,7 @@ const StreamControlOverlay = ({
                       sx={{ display: "block" }}
                     >
                       Host: {connectionSettingsState.ip}:
-                      {connectionSettingsState.apiPort}
+                      {connectionSettingsState.apiPort}/imswitch
                     </Typography>
                     <Typography
                       variant="caption"

--- a/src/components/SystemSettings.js
+++ b/src/components/SystemSettings.js
@@ -40,7 +40,7 @@ export default function SystemSettings() {
   const [isImSwitchRunning, setIsImSwitchRunning] = useState(false);
   const [diskUsage, setDiskUsage] = useState(null);
 
-  const base = `${hostIP}:${hostPort}/UC2ConfigController`;
+  const base = `${hostIP}:${hostPort}/imswitch/api/UC2ConfigController`;
 
   // API communication
   const callEndpoint = async (url) => {

--- a/src/components/TimelapseController.js
+++ b/src/components/TimelapseController.js
@@ -37,7 +37,7 @@ const TimelapseController = () => {
     const fetchParameters = async () => {
       try {
         const response = await fetch(
-          `${hostIP}:${hostPort}/TimelapseController/getCurrentTimelapseParameters`
+          `${hostIP}:${hostPort}/imswitch/api/TimelapseController/getCurrentTimelapseParameters`
         );
         const data = await response.json();
         if (data.detail === "Not Found") {
@@ -124,7 +124,7 @@ const TimelapseController = () => {
       filteredParameters.tPeriod = parameters.tPeriod; // TODO: why is this even necessry?
 
       const response = await fetch(
-        `${hostIP}:${hostPort}/TimelapseController/start_multicolour_timelapse_workflow`,
+        `${hostIP}:${hostPort}/imswitch/api/TimelapseController/start_multicolour_timelapse_workflow`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -143,7 +143,7 @@ const TimelapseController = () => {
   const handleStop = async () => {
     try {
       const response = await fetch(
-        `${hostIP}:${hostPort}/TimelapseController/stop_workflow_tl`,
+        `${hostIP}:${hostPort}/imswitch/api/TimelapseController/stop_workflow_tl`,
         { method: "get" }
       );
       const result = await response.json();

--- a/src/components/UC2ConfigurationController.jsx
+++ b/src/components/UC2ConfigurationController.jsx
@@ -109,7 +109,7 @@ const UC2ConfigurationController = () => {
 
 
   const fetchAvailableSetups = useCallback(() => {
-    const url = `${hostIP}:${hostPort}/UC2ConfigController/returnAvailableSetups`;
+    const url = `${hostIP}:${hostPort}/imswitch/api/UC2ConfigController/returnAvailableSetups`;
     dispatch(
       setNotification({
         message: "Loading available setups...",
@@ -148,7 +148,7 @@ const UC2ConfigurationController = () => {
     const maxRetries = 30; // 5 minutes with 10-second intervals
 
     const checkStatus = () => {
-      fetch(`${hostIP}:${hostPort}/UC2ConfigController/is_connected`)
+      fetch(`${hostIP}:${hostPort}/imswitch/api/UC2ConfigController/is_connected`)
         .then((res) => res.json())
         .then((data) => {
           if (data === true) {
@@ -225,7 +225,7 @@ const UC2ConfigurationController = () => {
       })
     );
 
-    const url = `${hostIP}:${hostPort}/UC2ConfigController/setSetupFileName?setupFileName=${encodeURIComponent(
+    const url = `${hostIP}:${hostPort}/imswitch/api/UC2ConfigController/setSetupFileName?setupFileName=${encodeURIComponent(
       selectedSetup
     )}&restartSoftware=${restartSoftware}`;
 
@@ -298,7 +298,7 @@ const UC2ConfigurationController = () => {
       })
     );
 
-    const url = `${hostIP}:${hostPort}/UC2ConfigController/readSetupFile?setupFileName=${encodeURIComponent(
+    const url = `${hostIP}:${hostPort}/imswitch/api/UC2ConfigController/readSetupFile?setupFileName=${encodeURIComponent(
       selectedFileForEdit
     )}`;
 
@@ -469,7 +469,7 @@ const UC2ConfigurationController = () => {
       })
     );
 
-    const url = `${hostIP}:${hostPort}/UC2ConfigController/writeNewSetupFile?setupFileName=${encodeURIComponent(
+    const url = `${hostIP}:${hostPort}/imswitch/api/UC2ConfigController/writeNewSetupFile?setupFileName=${encodeURIComponent(
       finalFileName
     )}&setAsCurrentConfig=${setAsCurrentConfig}&restart=${restartAfterSave}&overwrite=${overwriteFile}`;
 

--- a/src/components/VirtualJoystickControl.js
+++ b/src/components/VirtualJoystickControl.js
@@ -59,7 +59,7 @@ export default function VirtualJoystickControl({ hostIP, hostPort }) {
       });
 
       await fetch(
-        `${hostIP}:${hostPort}/PositionerController/movePositionerForeverXYZA?${params}`
+        `${hostIP}:${hostPort}/imswitch/api/PositionerController/movePositionerForeverXYZA?${params}`
       );
     } catch (error) {
       console.error("Error sending movement command:", error);

--- a/src/components/VizarrViewer.jsx
+++ b/src/components/VizarrViewer.jsx
@@ -151,10 +151,10 @@ const VizarrViewer = ({
     }
     
     // Build URL from connection settings
-    // Check if zarrUrl already starts with /data/ to avoid double prefix
-    const urlPath = zarrUrl.startsWith("/data/") || zarrUrl.startsWith("/data") 
+    // Check if zarrUrl already starts with /imswitch/data/ to avoid double prefix
+    const urlPath = zarrUrl.startsWith("/imswitch/data/") || zarrUrl.startsWith("/imswitch/data") 
       ? zarrUrl 
-      : `/data${zarrUrl}`;
+      : `/imswitch/data${zarrUrl}`;
     return `${connectionSettings.ip}:${connectionSettings.apiPort}${urlPath}`;
   }, [zarrUrl, connectionSettings.ip, connectionSettings.apiPort]);
   

--- a/src/components/WiFiController.jsx
+++ b/src/components/WiFiController.jsx
@@ -15,7 +15,7 @@ const WiFiController = () => {
   const hostIP = connectionSettingsState.ip;
 
   // Construct Internet Access URL from backend connection settings
-  // According to developer: if ImSwitch URL is {protocol}://{hostname}:8001/imswitch/index.html
+  // According to developer: if ImSwitch URL is {protocol}://{hostname}/imswitch/ui/index.html
   // then device-admin Internet Access page is {protocol}://{hostname}/admin/panel/internet
   const internetAccessUrl = `${hostIP}/admin/panel/internet?nav=hidden&theme=dark`;
 

--- a/src/components/WiFiController.test.js
+++ b/src/components/WiFiController.test.js
@@ -13,8 +13,8 @@ const createMockStore = (hostIP = "http://192.168.1.1") => {
     preloadedState: {
       connectionSettingsState: {
         ip: hostIP,
-        apiPort: "8001",
-        websocketPort: "8001",
+        apiPort: "80",
+        websocketPort: "80",
       },
     },
   });

--- a/src/components/navigation/SettingsMenu.jsx
+++ b/src/components/navigation/SettingsMenu.jsx
@@ -65,7 +65,7 @@ const SettingsMenu = ({ onNavigate }) => {
   const allowAccess = isBackendConnected || isDeveloperMode;
 
   // API endpoint for disk usage - following Copilot Instructions for API communication
-  const base = `${connectionSettings.ip}:${connectionSettings.apiPort}/UC2ConfigController`;
+  const base = `${connectionSettings.ip}:${connectionSettings.apiPort}/imswitch/api/UC2ConfigController`;
 
   // Fetch disk usage when backend is connected - following Copilot Instructions
   useEffect(() => {
@@ -248,7 +248,7 @@ const SettingsMenu = ({ onNavigate }) => {
               color="text.secondary"
               sx={{ display: "block", mb: 1 }}
             >
-              {connectionSettings.ip}:{connectionSettings.apiPort}
+              {connectionSettings.ip}:{connectionSettings.apiPort}/imswitch
             </Typography>
           )}
           {!hasConnectionSettings && (

--- a/src/context/WebSocketContext.js
+++ b/src/context/WebSocketContext.js
@@ -10,6 +10,7 @@ export const WebSocketProvider = ({ hostIP, children }) => {
   useEffect(() => {
     console.log("Connecting to WebSocket server:", hostIP, wsPort);
     const socket = io(`${hostIP}:8002`, {
+      path: '/imswitch/socket.io/',
       transports: ["websocket"],
     });
 

--- a/src/middleware/WebSocketHandler.js
+++ b/src/middleware/WebSocketHandler.js
@@ -58,7 +58,7 @@ const WebSocketHandler = () => {
       }
 
       try {
-        console.debug(`Checking UC2 connection to ${ip}:${port}`);
+        console.debug(`Checking UC2 connection to ${ip}:${port}/imswitch`);
 
         // Use cross-browser compatible fetch with timeout
         const response = await fetchWithTimeout(
@@ -147,7 +147,7 @@ const WebSocketHandler = () => {
         cleanIP = testIP;
       }
 
-      const socketIOUrl = `${protocol}://${cleanIP}:${testPort}/imswitch/socket.io`;
+      const socketIOUrl = `${protocol}://${cleanIP}:${testPort}`;
 
       console.log(
         `Testing Socket.IO connection to: ${socketIOUrl} (protocol: ${protocol})`
@@ -157,6 +157,7 @@ const WebSocketHandler = () => {
       return new Promise((resolve) => {
         try {
           const testSocket = io(socketIOUrl, {
+            path: '/imswitch/socket.io/',
             transports: ["websocket"], // Force WebSocket transport
             timeout: 5000,
             forceNew: true, // Create new connection for test
@@ -276,6 +277,7 @@ const WebSocketHandler = () => {
 
     // Create new socket instance for this component/tab
     const socket = io(address, {
+      path: '/imswitch/socket.io/',
       transports: ["websocket"],
       secure: protocol === "https", // Enable secure connection for HTTPS
     });

--- a/src/middleware/WebSocketHandler.js
+++ b/src/middleware/WebSocketHandler.js
@@ -62,7 +62,7 @@ const WebSocketHandler = () => {
 
         // Use cross-browser compatible fetch with timeout
         const response = await fetchWithTimeout(
-          `${ip}:${port}/UC2ConfigController/is_connected`,
+          `${ip}:${port}/imswitch/api/UC2ConfigController/is_connected`,
           { method: "GET" },
           10000
         );
@@ -147,7 +147,7 @@ const WebSocketHandler = () => {
         cleanIP = testIP;
       }
 
-      const socketIOUrl = `${protocol}://${cleanIP}:${testPort}`;
+      const socketIOUrl = `${protocol}://${cleanIP}:${testPort}/imswitch/socket.io`;
 
       console.log(
         `Testing Socket.IO connection to: ${socketIOUrl} (protocol: ${protocol})`

--- a/src/middleware/fetchLaserControllerCurrentValues.js
+++ b/src/middleware/fetchLaserControllerCurrentValues.js
@@ -19,7 +19,7 @@ const fetchLaserControllerCurrentValues = async (dispatch, connectionSettings, l
         try {
           const encodedLaserName = encodeURIComponent(laserName);
           const response = await fetch(
-            `${connectionSettings.ip}:${connectionSettings.apiPort}/LaserController/getLaserValue?laserName=${encodedLaserName}`
+            `${connectionSettings.ip}:${connectionSettings.apiPort}/imswitch/api/LaserController/getLaserValue?laserName=${encodedLaserName}`
           );
           
           if (!response.ok) {

--- a/src/state/slices/ConnectionSettingsSlice.js
+++ b/src/state/slices/ConnectionSettingsSlice.js
@@ -8,8 +8,8 @@ const getSmartDefaults = () => {
 
   return {
     ip: `${protocol}://${hostname}`,
-    websocketPort: 8001, // Both services now defaults on same port
-    apiPort: 8001,
+    websocketPort: 80, // Both services now defaults on same port
+    apiPort: 80,
   };
 };
 

--- a/src/themes/darkTheme.js
+++ b/src/themes/darkTheme.js
@@ -76,7 +76,7 @@ export const darkTheme = createTheme({
           font-display: swap;
           font-weight: 400;
           src: local('Roboto'),
-               url('/imswitch/fonts/Roboto-Regular.ttf') format('truetype');
+               url('/imswitch/ui/fonts/Roboto-Regular.ttf') format('truetype');
         }
         @font-face {
           font-family: 'Roboto';
@@ -84,7 +84,7 @@ export const darkTheme = createTheme({
           font-display: swap;
           font-weight: 700;
           src: local('Roboto Bold'),
-               url('/imswitch/fonts/Roboto-Bold.ttf') format('truetype');
+               url('/imswitch/ui/fonts/Roboto-Bold.ttf') format('truetype');
         }
       `,
     },

--- a/src/themes/lightTheme.js
+++ b/src/themes/lightTheme.js
@@ -65,7 +65,7 @@ export const lightTheme = createTheme({
           font-display: swap;
           font-weight: 400;
           src: local('Roboto'),
-               url('/imswitch/fonts/Roboto-Regular.ttf') format('truetype');
+               url('/imswitch/ui/fonts/Roboto-Regular.ttf') format('truetype');
         }
         @font-face {
           font-family: 'Roboto';
@@ -73,7 +73,7 @@ export const lightTheme = createTheme({
           font-display: swap;
           font-weight: 700;
           src: local('Roboto Bold'),
-               url('/imswitch/fonts/Roboto-Bold.ttf') format('truetype');
+               url('/imswitch/ui/fonts/Roboto-Bold.ttf') format('truetype');
         }
       `,
     },


### PR DESCRIPTION
This PR updates the React frontend to match the changes made in https://github.com/openUC2/ImSwitch/pull/204 . This PR also changes the default port for the backend from 8001 to 80, as part of https://github.com/openUC2/rpi-imswitch-os/pull/97

Files I'm especially unsure about (@beniroquai please review my changes):
- `/src/App.jsx`
- `/src/middleware/WebSocketHandler.js`
- `/src/components/VizarrViewer.jsx`
- `/src/components/StreamControlOverlay.js`
- `/src/components/LightsheetController.jsx`
- `/src/components/ConnectionSettings.jsx`
- `/src/components/navigation/SettingsMenu.jsx`

Things to do in future PRs, not this one:

- Consolidate the building of an API root URL (as `${connectionSettings.ip}:${connectionSettings.apiPort}/imswitch/api`) into a single place (or only a few places), to make it easier to change the API root URL in the future! 

This work is tracked on Notion at https://www.notion.so/Reverse-proxy-ImSwitch-on-port-80-via-our-ingress-proxy-28a4e612c78a80b6a78ce8938edaacd1?source=copy_link